### PR TITLE
fix: Show ampersands in names of variable symbols and macro parameters in macro tracer

### DIFF
--- a/clients/vscode-hlasmplugin/src/test/suite/integration.test.ts
+++ b/clients/vscode-hlasmplugin/src/test/suite/integration.test.ts
@@ -188,10 +188,10 @@ suite('Integration Test Suite', () => {
 							variables = variablesResult.variables;
 						else
 							variables = variablesResult.body.variables;
-						if (variables.length == 1 && variables[0].value == 'SOMETHING' && variables[0].name == 'VAR2')
+						if (variables.length == 1 && variables[0].value == 'SOMETHING' && variables[0].name == '&VAR2')
 							done();
 						else
-							done('Wrong debug variable VAR2');
+							done('Wrong debug variable &VAR2');
 					});
 				})}, 1000);
 			}, 1000)

--- a/language_server/test/dap/feature_launch_test.cpp
+++ b/language_server/test/dap/feature_launch_test.cpp
@@ -373,19 +373,19 @@ TEST_F(feature_launch_test, variables)
         EXPECT_FALSE(var.find("name") == var.end());
         EXPECT_FALSE(var.find("value") == var.end());
         EXPECT_FALSE(var.find("variablesReference") == var.end());
-        if (var["name"] == "VARA")
+        if (var["name"] == "&VARA")
         {
             EXPECT_EQ(var["value"], json("4"));
             EXPECT_EQ(var["type"], json("A_TYPE"));
             ++var_count;
         }
-        else if (var["name"] == "VARB")
+        else if (var["name"] == "&VARB")
         {
             EXPECT_EQ(var["value"], json("TRUE"));
             EXPECT_EQ(var["type"], json("B_TYPE"));
             ++var_count;
         }
-        else if (var["name"] == "VARC")
+        else if (var["name"] == "&VARC")
         {
             EXPECT_EQ(var["value"], json("STH"));
             EXPECT_EQ(var["type"], json("C_TYPE"));

--- a/parser_library/src/debugging/macro_param_variable.cpp
+++ b/parser_library/src/debugging/macro_param_variable.cpp
@@ -26,13 +26,18 @@ macro_param_variable::macro_param_variable(const context::macro_param_base& para
 {
     if (!index_.empty())
         name_.emplace(std::to_string(index_.back()));
+    else
+        name_.emplace("&" + *macro_param_.id);
 }
 
 const std::string& macro_param_variable::get_string_value() const { return macro_param_.get_value(index_); };
 
 set_type macro_param_variable::type() const { return set_type::C_TYPE; }
 
-const std::string& macro_param_variable::get_string_name() const { return *macro_param_.id; }
+const std::string& macro_param_variable::get_string_name() const
+{
+    throw std::runtime_error("Function macro_param_variable::get_string_name should never be called!");
+}
 
 bool macro_param_variable::is_scalar() const { return macro_param_.size(index_) == 0; }
 

--- a/parser_library/src/debugging/set_symbol_variable.cpp
+++ b/parser_library/src/debugging/set_symbol_variable.cpp
@@ -15,6 +15,7 @@
 #include "set_symbol_variable.h"
 
 #include <cassert>
+#include <stdexcept>
 
 using namespace hlasm_plugin::parser_library;
 using namespace hlasm_plugin::parser_library::debugging;
@@ -42,6 +43,7 @@ set_symbol_variable::set_symbol_variable(const context::set_symbol_base& set_sym
     : set_symbol_(set_sym)
     , index_()
 {
+    name_.emplace("&" + *set_symbol_.id);
     fill_string_value();
 }
 
@@ -50,7 +52,10 @@ const std::string& set_symbol_variable::get_string_value() const { return get_va
 
 set_type set_symbol_variable::type() const { return (set_type)set_symbol_.type; }
 
-const std::string& set_symbol_variable::get_string_name() const { return *set_symbol_.id; }
+const std::string& set_symbol_variable::get_string_name() const
+{
+    throw std::runtime_error("Function set_symbol_variable::get_string_name should never be called!");
+}
 
 bool set_symbol_variable::is_scalar() const
 {

--- a/parser_library/test/debugging/debugger_test.cpp
+++ b/parser_library/test/debugging/debugger_test.cpp
@@ -168,11 +168,11 @@ struct frame_vars
         , locals(std::move(locals))
         , ord_syms(std::move(ords))
     {
-        this->globals["SYSDATE"];
-        this->globals["SYSDATC"];
-        this->globals["SYSTIME"];
-        this->globals["SYSPARM"];
-        this->globals["SYSOPT_RENT"];
+        this->globals["&SYSDATE"];
+        this->globals["&SYSDATC"];
+        this->globals["&SYSTIME"];
+        this->globals["&SYSPARM"];
+        this->globals["&SYSOPT_RENT"];
     }
     std::unordered_map<std::string, test_var_value> globals;
     std::unordered_map<std::string, test_var_value> locals;
@@ -289,20 +289,20 @@ TEST(debugger, test)
 
     d.next();
     m.wait_for_stopped();
-    exp_frame_vars[0].locals.emplace("VAR", 2);
+    exp_frame_vars[0].locals.emplace("&VAR", 2);
     exp_frames[0].begin_line = exp_frames[0].end_line = 2;
     EXPECT_TRUE(check_step(d, exp_frames, exp_frame_vars));
 
     d.next();
     m.wait_for_stopped();
     exp_frames[0].begin_line = exp_frames[0].end_line = 3;
-    exp_frame_vars[0].locals.emplace("BOOL", true);
+    exp_frame_vars[0].locals.emplace("&BOOL", true);
     EXPECT_TRUE(check_step(d, exp_frames, exp_frame_vars));
 
     d.next();
     m.wait_for_stopped();
     exp_frames[0].begin_line = exp_frames[0].end_line = 5;
-    exp_frame_vars[0].locals.emplace("STR", "SOMETHING");
+    exp_frame_vars[0].locals.emplace("&STR", "SOMETHING");
     EXPECT_TRUE(check_step(d, exp_frames, exp_frame_vars));
 
     d.next();
@@ -317,17 +317,17 @@ TEST(debugger, test)
         frame_vars(std::unordered_map<std::string, test_var_value> {}, // empty globals
             std::unordered_map<std::string, test_var_value> {
                 // macro locals
-                { "SYSLIST",
+                { "&SYSLIST",
                     test_var_value("(10,13)",
                         list { { "0", std::make_shared<test_var_value>("10") },
                             { "1", std::make_shared<test_var_value>("13") } }) },
-                { "SYSECT", "" },
-                { "SYSNDX", 0 },
-                { "SYSSTYP", "" },
-                { "SYSLOC", "" },
-                { "SYSNEST", 1 },
-                { "SYSMAC", test_var_value() },
-                { "VAR", "13" },
+                { "&SYSECT", "" },
+                { "&SYSNDX", 0 },
+                { "&SYSSTYP", "" },
+                { "&SYSLOC", "" },
+                { "&SYSNEST", 1 },
+                { "&SYSMAC", test_var_value() },
+                { "&VAR", "13" },
             },
             {} // empty ord symbols
             ));
@@ -393,7 +393,7 @@ TEST(debugger, var_symbol_array)
 
     d.next();
     m.wait_for_stopped();
-    exp_frame_vars[0].locals.emplace("VARP",
+    exp_frame_vars[0].locals.emplace("&VARP",
         list { { "30", std::make_shared<test_var_value>(1) },
             { "31", std::make_shared<test_var_value>(456) },
             { "32", std::make_shared<test_var_value>(48) },


### PR DESCRIPTION
Added ampersands in names of variable symbols and macro parameters in macro tracer.

Closes #74 