### PR TITLE
add an option to tolerate unavailable directories in the macro library concatenation

### DIFF
--- a/clients/vscode-hlasmplugin/proc_grps_schema
+++ b/clients/vscode-hlasmplugin/proc_grps_schema
@@ -15,8 +15,26 @@
                     "libs": {
                         "type" : "array",
                         "description" : "List of folders containing external files such as macros and copy.\nAll files inside these folders are being automatically recognized as HLASM.\nIf you would like to use dependency files with a specific extension, create an extension wildcard in pgm_conf.json for it.\nExtension wildcards must follow the format: [anything]*.[1+ non-whitespace characters], e.g. libs/*.hlasm or *.asm",
-                        "items" : {
-                            "type" : "string"
+                        "items": {
+                            "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "path": {
+                                            "type": "string",
+                                            "description": "Path to the folder containing external files."
+                                        },
+                                        "optional": {
+                                            "type": "boolean",
+                                            "description": "Specifies if it is acceptable not to be able locate the folder."
+                                        }
+                                    },
+                                    "required": [ "path" ]
+                                }
+                            ]
                         }
                     }
                 },

--- a/parser_library/src/workspaces/file_manager.h
+++ b/parser_library/src/workspaces/file_manager.h
@@ -53,7 +53,8 @@ public:
     virtual processor_file_ptr find_processor_file(const std::string& key) = 0;
 
     // Returns list of all files in a directory. Returns associative array with pairs file path - file name.
-    virtual std::unordered_map<std::string, std::string> list_directory_files(const std::string& path) = 0;
+    virtual std::unordered_map<std::string, std::string> list_directory_files(
+        const std::string& path, bool optional) = 0;
 
     virtual bool file_exists(const std::string& file_name) = 0;
     virtual bool lib_file_exists(const std::string& lib_path, const std::string& file_name) = 0;

--- a/parser_library/src/workspaces/file_manager_impl.cpp
+++ b/parser_library/src/workspaces/file_manager_impl.cpp
@@ -106,13 +106,17 @@ std::vector<processor_file*> file_manager_impl::list_updated_files()
     return list;
 }
 
-std::unordered_map<std::string, std::string> file_manager_impl::list_directory_files(const std::string& path)
+std::unordered_map<std::string, std::string> file_manager_impl::list_directory_files(
+    const std::string& path, bool optional)
 {
     std::filesystem::path lib_p(path);
     std::unordered_map<std::string, std::string> found_files;
     try
     {
         std::filesystem::directory_entry dir(lib_p);
+        if (!dir.exists() && optional)
+            return found_files;
+
         if (!dir.is_directory())
         {
             add_diagnostic(diagnostic_s { "",

--- a/parser_library/src/workspaces/file_manager_impl.h
+++ b/parser_library/src/workspaces/file_manager_impl.h
@@ -38,26 +38,26 @@ public:
     file_manager_impl(file_manager_impl&&) = delete;
     file_manager_impl& operator=(file_manager_impl&&) = delete;
 
-    virtual void collect_diags() const override;
+    void collect_diags() const override;
 
-    virtual file_ptr add_file(const file_uri&) override;
-    virtual processor_file_ptr add_processor_file(const file_uri&) override;
-    virtual void remove_file(const file_uri&) override;
+    file_ptr add_file(const file_uri&) override;
+    processor_file_ptr add_processor_file(const file_uri&) override;
+    void remove_file(const file_uri&) override;
 
-    virtual file_ptr find(const std::string& key) override;
-    virtual processor_file_ptr find_processor_file(const std::string& key) override;
+    file_ptr find(const std::string& key) override;
+    processor_file_ptr find_processor_file(const std::string& key) override;
 
     // Returns array of files that were updated since this method was last called
     virtual std::vector<processor_file*> list_updated_files();
-    virtual std::unordered_map<std::string, std::string> list_directory_files(const std::string& path) override;
+    std::unordered_map<std::string, std::string> list_directory_files(const std::string& path, bool optional) override;
 
-    virtual void did_open_file(const std::string& document_uri, version_t version, std::string text) override;
-    virtual void did_change_file(
+    void did_open_file(const std::string& document_uri, version_t version, std::string text) override;
+    void did_change_file(
         const std::string& document_uri, version_t version, const document_change* changes, size_t ch_size) override;
-    virtual void did_close_file(const std::string& document_uri) override;
+    void did_close_file(const std::string& document_uri) override;
 
-    virtual bool file_exists(const std::string& file_name) override;
-    virtual bool lib_file_exists(const std::string& lib_path, const std::string& file_name) override;
+    bool file_exists(const std::string& file_name) override;
+    bool lib_file_exists(const std::string& lib_path, const std::string& file_name) override;
 
     virtual ~file_manager_impl() = default;
 

--- a/parser_library/src/workspaces/library.cpp
+++ b/parser_library/src/workspaces/library.cpp
@@ -34,7 +34,14 @@ library_local::library_local(file_manager& file_manager,
     , optional_(optional)
 {}
 
-library_local::library_local(library_local&&) noexcept = default;
+library_local::library_local(library_local&& l) noexcept
+    : file_manager_(l.file_manager_)
+    , lib_path_(std::move(l.lib_path_))
+    , files_(std::move(l.files_))
+    , extensions_(std::move(l.extensions_))
+    , files_loaded_(l.files_loaded_)
+    , optional_(l.optional_)
+{}
 
 void library_local::collect_diags() const
 {

--- a/parser_library/src/workspaces/library.cpp
+++ b/parser_library/src/workspaces/library.cpp
@@ -24,17 +24,17 @@
 
 namespace hlasm_plugin::parser_library::workspaces {
 
-library_local::library_local(
-    file_manager& file_manager, std::string lib_path, std::shared_ptr<const extension_regex_map> extensions)
+library_local::library_local(file_manager& file_manager,
+    std::string lib_path,
+    std::shared_ptr<const extension_regex_map> extensions,
+    bool optional)
     : file_manager_(file_manager)
-    , lib_path_(lib_path)
-    , extensions_(extensions)
+    , lib_path_(std::move(lib_path))
+    , extensions_(std::move(extensions))
+    , optional_(optional)
 {}
 
-library_local::library_local(library_local&& l) noexcept
-    : file_manager_(l.file_manager_)
-    , extensions_(l.extensions_)
-{}
+library_local::library_local(library_local&&) noexcept = default;
 
 void library_local::collect_diags() const
 {
@@ -67,7 +67,7 @@ std::shared_ptr<processor> library_local::find_file(const std::string& file_name
 
 void library_local::load_files()
 {
-    auto files_list = file_manager_.list_directory_files(lib_path_);
+    auto files_list = file_manager_.list_directory_files(lib_path_, optional_);
     files_.clear();
     for (const auto& file : files_list)
     {

--- a/parser_library/src/workspaces/library.h
+++ b/parser_library/src/workspaces/library.h
@@ -44,22 +44,24 @@ class library_local : public library, public diagnosable_impl
 public:
     // takes reference to file manager that provides access to the files
     // and normalised path to directory that it wraps.
-    library_local(
-        file_manager& file_manager, std::string lib_path, std::shared_ptr<const extension_regex_map> extensions);
+    library_local(file_manager& file_manager,
+        std::string lib_path,
+        std::shared_ptr<const extension_regex_map> extensions,
+        bool optional = false);
 
     library_local(const library_local&) = delete;
     library_local& operator=(const library_local&) = delete;
 
-    library_local(library_local&& l) noexcept;
+    library_local(library_local&&) noexcept;
 
     void collect_diags() const override;
 
     const std::string& get_lib_path() const;
 
-    virtual std::shared_ptr<processor> find_file(const std::string& file) override;
+    std::shared_ptr<processor> find_file(const std::string& file) override;
 
     // this function should be called from workspace, once watchedFilesChanged request is implemented
-    virtual void refresh() override;
+    void refresh() override;
 
 private:
     file_manager& file_manager_;
@@ -69,6 +71,7 @@ private:
     std::shared_ptr<const extension_regex_map> extensions_;
     // indicates whether load_files function was called (not whether it was succesful)
     bool files_loaded_ = false;
+    bool optional_ = false;
 
     void load_files();
 };

--- a/parser_library/src/workspaces/workspace.cpp
+++ b/parser_library/src/workspaces/workspace.cpp
@@ -305,17 +305,45 @@ bool workspace::load_and_process_config()
 
         for (auto& lib_path_json : libs)
         {
+            bool optional = false;
+            std::string path;
+            bool valid = false;
+
             if (lib_path_json.is_string())
             {
                 // the added '/' will ensure the path always ends with directory separator
-                const std::string p = lib_path_json.get<std::string>();
-                std::filesystem::path lib_path(p.empty() ? p : p + '/');
+                path = lib_path_json.get<std::string>();
+                valid = true;
+            }
+            else if (lib_path_json.is_object() && lib_path_json.count("path"))
+            {
+                if (auto pp = lib_path_json.find("path"); pp != lib_path_json.cend() && pp->is_string())
+                {
+                    path = pp->get<std::string>();
+                    if (auto op = lib_path_json.find("optional"); op != lib_path_json.cend())
+                    {
+                        if (op->is_boolean())
+                        {
+                            optional = op->get<bool>();
+                            valid = true;
+                        }
+                    }
+                    else
+                        valid = true;
+                }
+            }
+
+            if (valid)
+            {
+                if (!path.empty())
+                    path += '/';
+                std::filesystem::path lib_path(std::move(path));
                 if (lib_path.is_absolute())
                     prc_grp.add_library(std::make_unique<library_local>(
-                        file_manager_, lib_path.lexically_normal().string(), extensions_ptr));
+                        file_manager_, lib_path.lexically_normal().string(), extensions_ptr, optional));
                 else if (lib_path.is_relative())
                     prc_grp.add_library(std::make_unique<library_local>(
-                        file_manager_, (ws_path / lib_path).lexically_normal().string(), extensions_ptr));
+                        file_manager_, (ws_path / lib_path).lexically_normal().string(), extensions_ptr, optional));
                 // else ignore, publish warning
             }
         }

--- a/parser_library/test/workspace/extension_handling_test.cpp
+++ b/parser_library/test/workspace/extension_handling_test.cpp
@@ -30,7 +30,7 @@ const std::string lib_path2 = "lib2/";
 
 class file_manager_extension_mock : public file_manager_impl
 {
-    virtual std::unordered_map<std::string, std::string> list_directory_files(const std::string&) override
+    std::unordered_map<std::string, std::string> list_directory_files(const std::string&, bool optional) override
     {
         return { { "Mac.hlasm", lib_path + "Mac.hlasm" } };
     }

--- a/parser_library/test/workspace/workspace_test.cpp
+++ b/parser_library/test/workspace/workspace_test.cpp
@@ -367,7 +367,7 @@ TEST_F(workspace_test, did_change_watched_files)
     ASSERT_EQ(collect_and_get_diags_size(ws, file_manager), (size_t)0);
 }
 
-TEST_F(workspace_test, missing_library_requried)
+TEST_F(workspace_test, missing_library_required)
 {
     for (auto type : { file_manager_opt_variant::old_school,
              file_manager_opt_variant::default_to_required,

--- a/parser_library/test/workspace/workspace_test.cpp
+++ b/parser_library/test/workspace/workspace_test.cpp
@@ -374,7 +374,8 @@ TEST_F(workspace_test, missing_library_required)
              file_manager_opt_variant::required })
     {
         file_manager_opt file_manager(type);
-        workspace ws("", "workspace_name", file_manager);
+        lib_config config;
+        workspace ws("", "workspace_name", file_manager, config);
         ws.open();
 
         ws.did_open_file("source1");
@@ -386,7 +387,8 @@ TEST_F(workspace_test, missing_library_required)
 TEST_F(workspace_test, missing_library_optional)
 {
     file_manager_opt file_manager(file_manager_opt_variant::optional);
-    workspace ws("", "workspace_name", file_manager);
+    lib_config config;
+    workspace ws("", "workspace_name", file_manager, config);
     ws.open();
 
     ws.did_open_file("source1");

--- a/parser_library/test/workspace/workspace_test.cpp
+++ b/parser_library/test/workspace/workspace_test.cpp
@@ -112,6 +112,59 @@ std::string pgroups_file = R"({
   ]
 })";
 
+std::string pgroups_file_old_school = R"({
+  "pgroups": [
+    {
+      "name": "P1",
+      "libs": [ "missing", "lib" ]
+    }
+  ]
+})";
+
+std::string pgroups_file_default = R"({
+  "pgroups": [
+    {
+      "name": "P1",
+      "libs": [
+        {
+          "path": "missing"
+        },
+        "lib"
+      ]
+    }
+  ]
+})";
+
+std::string pgroups_file_required = R"({
+  "pgroups": [
+    {
+      "name": "P1",
+      "libs": [
+        {
+          "path": "missing",
+          "optional": false
+        },
+        "lib"
+      ]
+    }
+  ]
+})";
+
+std::string pgroups_file_optional = R"({
+  "pgroups": [
+    {
+      "name": "P1",
+      "libs": [
+        {
+          "path": "missing",
+          "optional": true
+        },
+        "lib"
+      ]
+    }
+  ]
+})";
+
 std::string pgmconf_file = R"({
   "pgms": [
     {
@@ -187,7 +240,7 @@ public:
         files_.emplace(correct_macro_path, std::make_unique<file_with_text>(correct_macro_path, correct_macro_file));
     }
 
-    virtual std::unordered_map<std::string, std::string> list_directory_files(const std::string&) override
+    std::unordered_map<std::string, std::string> list_directory_files(const std::string&, bool optional) override
     {
         if (insert_correct_macro)
             return { { "ERROR", "ERROR" }, { "CORRECT", "CORRECT" } };
@@ -197,6 +250,53 @@ public:
     bool insert_correct_macro = true;
 };
 
+enum class file_manager_opt_variant
+{
+    old_school,
+    default_to_required,
+    required,
+    optional,
+};
+
+class file_manager_opt : public file_manager_impl
+{
+    std::unique_ptr<file_with_text> generate_proc_grps_file(file_manager_opt_variant variant)
+    {
+        switch (variant)
+        {
+            case file_manager_opt_variant::old_school:
+                return std::make_unique<file_with_text>("proc_grps.json", pgroups_file_old_school);
+            case file_manager_opt_variant::default_to_required:
+                return std::make_unique<file_with_text>("proc_grps.json", pgroups_file_default);
+            case file_manager_opt_variant::required:
+                return std::make_unique<file_with_text>("proc_grps.json", pgroups_file_required);
+            case file_manager_opt_variant::optional:
+                return std::make_unique<file_with_text>("proc_grps.json", pgroups_file_optional);
+        }
+        throw std::logic_error("Not implemented");
+    }
+
+public:
+    file_manager_opt(file_manager_opt_variant variant)
+    {
+        files_.emplace(hlasmplugin_folder + "proc_grps.json", generate_proc_grps_file(variant));
+        files_.emplace(
+            hlasmplugin_folder + "pgm_conf.json", std::make_unique<file_with_text>("pgm_conf.json", pgmconf_file));
+        files_.emplace("source1", std::make_unique<file_with_text>("source1", source_using_macro_file_no_error));
+        files_.emplace(correct_macro_path, std::make_unique<file_with_text>(correct_macro_path, correct_macro_file));
+    }
+    std::unordered_map<std::string, std::string> list_directory_files(const std::string& path, bool optional) override
+    {
+        if (path == "lib/" || path == "lib\\")
+            return { { "CORRECT", "CORRECT" } };
+
+        if (!optional)
+            add_diagnostic(
+                diagnostic_s { "", {}, "L0001", "Unable to load library - path does not exist and is not optional." });
+
+        return {};
+    }
+};
 
 
 TEST_F(workspace_test, did_close_file)
@@ -265,4 +365,30 @@ TEST_F(workspace_test, did_change_watched_files)
     changes.push_back(document_change({ { 0, 0 }, { 0, 0 } }, new_text.c_str(), new_text.size()));
     ws.did_change_file("source3", changes.data(), changes.size());
     ASSERT_EQ(collect_and_get_diags_size(ws, file_manager), (size_t)0);
+}
+
+TEST_F(workspace_test, missing_library_requried)
+{
+    for (auto type : { file_manager_opt_variant::old_school,
+             file_manager_opt_variant::default_to_required,
+             file_manager_opt_variant::required })
+    {
+        file_manager_opt file_manager(type);
+        workspace ws("", "workspace_name", file_manager);
+        ws.open();
+
+        ws.did_open_file("source1");
+        EXPECT_GE(collect_and_get_diags_size(ws, file_manager), (size_t)1);
+        EXPECT_TRUE(std::any_of(diags().begin(), diags().end(), [](const auto& d) { return d.code == "L0001"; }));
+    }
+}
+
+TEST_F(workspace_test, missing_library_optional)
+{
+    file_manager_opt file_manager(file_manager_opt_variant::optional);
+    workspace ws("", "workspace_name", file_manager);
+    ws.open();
+
+    ws.did_open_file("source1");
+    EXPECT_EQ(collect_and_get_diags_size(ws, file_manager), (size_t)0);
 }


### PR DESCRIPTION
In my projects some directories from my macro library concatenation may not always be present, but it seems impractical to keep changing the configuration JSON file.
This change allows the user to mark certain entries in the configuration as optional and therefore suppress the L0001 error message when the plug-in cannot find the directory. The behavior for existing configuration files is preserved.