### PR TITLE
chore: Improve GA pipeline so it accepts pull requests from forks

### DIFF
--- a/.github/workflows/Sonarcloud-build.yml
+++ b/.github/workflows/Sonarcloud-build.yml
@@ -80,5 +80,3 @@ jobs:
             clients/vscode-hlasmplugin/coverage/lcov.info
             pr-info/
             !build/bin/
-            !build/**/dist/
-            !build/**/.git/

--- a/.github/workflows/Sonarcloud-build.yml
+++ b/.github/workflows/Sonarcloud-build.yml
@@ -78,5 +78,6 @@ jobs:
           path: |
             build/
             !build/bin
+            !build/externals
             clients/vscode-hlasmplugin/coverage/lcov.info
             pr-info/

--- a/.github/workflows/Sonarcloud-build.yml
+++ b/.github/workflows/Sonarcloud-build.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Get version
         run: echo "VERSION=$(node -e "console.log(require('./clients/vscode-hlasmplugin/package.json').version)")" >> $GITHUB_ENV
       - name: Requirements install
@@ -71,9 +71,6 @@ jobs:
           echo $(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH") > pr-info/pr-number.txt
           echo -Dsonar.pullrequest.key=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH") > pr-info/pr-number-arg.txt
           echo -Dsonar.pullrequest.branch=${{ github.head_ref }} > pr-info/head-branch-arg.txt
-      - name: Push setting
-        if: github.event_name == 'push'
-          mkdir pr-info
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/Sonarcloud-build.yml
+++ b/.github/workflows/Sonarcloud-build.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Merge raw profiles
         run: cd build/bin && llvm-profdata-8 merge -o hlasm_profile library.rawprof server.rawprof
       - name: Generate lcov coverage
-        run: cd build/bin && llvm-cov-8 show -instr-profile hlasm_profile library_test -object server_test > coverage.txt
+        run: cd build/bin && llvm-cov-8 show -instr-profile hlasm_profile library_test -object server_test > ../coverage.txt
       - name: Pull request setting
         if: github.event_name == 'pull_request'
         run: |
@@ -77,7 +77,7 @@ jobs:
           name: bw-output
           path: |
             build/
-            !build/bin
-            !build/externals
+            !build/bin/
+            !build/externals/
             clients/vscode-hlasmplugin/coverage/lcov.info
             pr-info/

--- a/.github/workflows/Sonarcloud-build.yml
+++ b/.github/workflows/Sonarcloud-build.yml
@@ -76,8 +76,6 @@ jobs:
         with:
           name: bw-output
           path: |
-            build/bw-output/
-            build/bin/coverage.txt
-            build/generated_parser/
+            build/
             clients/vscode-hlasmplugin/coverage/lcov.info
             pr-info/

--- a/.github/workflows/Sonarcloud-build.yml
+++ b/.github/workflows/Sonarcloud-build.yml
@@ -77,6 +77,6 @@ jobs:
           name: bw-output
           path: |
             build/
-            !build/bin/
             clients/vscode-hlasmplugin/coverage/lcov.info
             pr-info/
+            !build/bin/

--- a/.github/workflows/Sonarcloud-build.yml
+++ b/.github/workflows/Sonarcloud-build.yml
@@ -80,3 +80,5 @@ jobs:
             clients/vscode-hlasmplugin/coverage/lcov.info
             pr-info/
             !build/bin/
+            !build/**/dist/
+            !build/**/.git/

--- a/.github/workflows/Sonarcloud-build.yml
+++ b/.github/workflows/Sonarcloud-build.yml
@@ -75,8 +75,8 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           name: bw-output
-          path: 
-            build/bw-output
+          path: |
+            build/bw-output/
             build/bin/coverage.txt
             build/generated_parser/
             clients/vscode-hlasmplugin/coverage/lcov.info

--- a/.github/workflows/Sonarcloud-build.yml
+++ b/.github/workflows/Sonarcloud-build.yml
@@ -1,0 +1,86 @@
+#
+# Copyright (c) 2019 Broadcom.
+# The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+#
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Broadcom, Inc. - initial API and implementation
+#
+
+name: SonarCloud build
+
+on:
+  pull_request:
+    branches:
+      - development
+      - master
+  push:
+    branches:
+      - development
+      - master
+
+jobs:
+  sonarcloud-build:
+    name: SonarCloud build
+    runs-on: ubuntu-18.04
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Get version
+        run: echo "VERSION=$(node -e "console.log(require('./clients/vscode-hlasmplugin/package.json').version)")" >> $GITHUB_ENV
+      - name: Requirements install
+        run: sudo apt-get update && sudo apt-get install uuid-dev ninja-build libc++-8-dev libc++abi-8-dev
+      - name: Configure
+        run: >
+          mkdir build && cd build &&
+          cmake -DCMAKE_BUILD_TYPE=Debug
+          -DCMAKE_C_COMPILER=clang-8
+          -DCMAKE_CXX_COMPILER=clang++-8
+          -DCMAKE_CXX_FLAGS="-fprofile-instr-generate -fcoverage-mapping"
+          ../
+      - name: Sonar build wrapper download
+        run: >
+          cd build &&
+          curl -LsS https://sonarcloud.io/static/cpp/build-wrapper-linux-x86.zip > build-wrapper-linux-x86.zip &&
+          unzip build-wrapper-linux-x86.zip &&
+          cp build-wrapper-linux-x86/* .
+      - name: Build
+        run: cd build && ./build-wrapper-linux-x86-64 --out-dir bw-output make -j 4 clean all
+      - name: Server Test
+        run: |
+          cd build/bin
+          LLVM_PROFILE_FILE="library.rawprof" ./library_test 
+          LLVM_PROFILE_FILE="server.rawprof" ./server_test
+      - name: Extension Test
+        uses: GabrielBB/xvfb-action@v1.0
+        with:
+          run: npm --prefix clients/vscode-hlasmplugin test
+      - name: Merge raw profiles
+        run: cd build/bin && llvm-profdata-8 merge -o hlasm_profile library.rawprof server.rawprof
+      - name: Generate lcov coverage
+        run: cd build/bin && llvm-cov-8 show -instr-profile hlasm_profile library_test -object server_test > coverage.txt
+      - name: Pull request setting
+        if: github.event_name == 'pull_request'
+        run: |
+          mkdir pr-info
+          echo $(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH") > pr-info/pr-number.txt
+          echo -Dsonar.pullrequest.key=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH") > pr-info/pr-number-arg.txt
+          echo -Dsonar.pullrequest.branch=${{ github.head_ref }} > pr-info/head-branch-arg.txt
+      - name: Push setting
+        if: github.event_name == 'push'
+          mkdir pr-info
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: bw-output
+          path: 
+            build/bw-output
+            build/bin/coverage.txt
+            build/generated_parser/
+            clients/vscode-hlasmplugin/coverage/lcov.info
+            pr-info/

--- a/.github/workflows/Sonarcloud-build.yml
+++ b/.github/workflows/Sonarcloud-build.yml
@@ -78,6 +78,5 @@ jobs:
           path: |
             build/
             !build/bin/
-            !build/externals/
             clients/vscode-hlasmplugin/coverage/lcov.info
             pr-info/

--- a/.github/workflows/Sonarcloud-build.yml
+++ b/.github/workflows/Sonarcloud-build.yml
@@ -77,5 +77,6 @@ jobs:
           name: bw-output
           path: |
             build/
+            !build/bin
             clients/vscode-hlasmplugin/coverage/lcov.info
             pr-info/

--- a/.github/workflows/Sonarcloud-scan.yml
+++ b/.github/workflows/Sonarcloud-scan.yml
@@ -15,14 +15,10 @@
 name: SonarCloud
 
 on:
-  pull_request:
-    branches:
-      - development
-      - master
-  push:
-    branches:
-      - development
-      - master
+  workflow_run:
+    workflows: ["SonarCloud build"]
+    types:
+      - completed
 
 jobs:
   sonar:
@@ -30,45 +26,33 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
+      - name: 'Download build output'
+        uses: actions/github-script@v3.1.0
+        with:
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "bw_output"
+            })[0];
+            var download = await github.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/bw-artifact.zip', Buffer.from(download.data));
+      - run: unzip bw-artifact.zip
+      
+      
       - name: Get version
         run: echo "VERSION=$(node -e "console.log(require('./clients/vscode-hlasmplugin/package.json').version)")" >> $GITHUB_ENV
-      - name: Requirements install
-        run: sudo apt-get update && sudo apt-get install uuid-dev ninja-build libc++-8-dev libc++abi-8-dev
-      - name: Configure
-        run: >
-          mkdir build && cd build &&
-          cmake -DCMAKE_BUILD_TYPE=Debug
-          -DCMAKE_C_COMPILER=clang-8
-          -DCMAKE_CXX_COMPILER=clang++-8
-          -DCMAKE_CXX_FLAGS="-fprofile-instr-generate -fcoverage-mapping"
-          ../
-      - name: Sonar build wrapper download
-        run: >
-          cd build &&
-          curl -LsS https://sonarcloud.io/static/cpp/build-wrapper-linux-x86.zip > build-wrapper-linux-x86.zip &&
-          unzip build-wrapper-linux-x86.zip &&
-          cp build-wrapper-linux-x86/* .
-      - name: Build
-        run: cd build && ./build-wrapper-linux-x86-64 --out-dir bw-output make -j 4 clean all
-      - name: Server Test
-        run: |
-          cd build/bin
-          LLVM_PROFILE_FILE="library.rawprof" ./library_test 
-          LLVM_PROFILE_FILE="server.rawprof" ./server_test
-      - name: Extension Test
-        uses: GabrielBB/xvfb-action@v1.0
-        with:
-          run: npm --prefix clients/vscode-hlasmplugin test
-      - name: Merge raw profiles
-        run: cd build/bin && llvm-profdata-8 merge -o hlasm_profile library.rawprof server.rawprof
-      - name: Generate lcov coverage
-        run: cd build/bin && llvm-cov-8 show -instr-profile hlasm_profile library_test -object server_test > coverage.txt
-      - name: Pull request setting
-        if: github.event_name == 'pull_request'
-        run: |
-          echo PR_NUMBER=-Dsonar.pullrequest.key=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH") >> $GITHUB_ENV
-          echo HEAD_BRANCH=-Dsonar.pullrequest.branch=${{ github.head_ref }} >> $GITHUB_ENV
+
       - name: Sonar scan
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -99,5 +83,5 @@ jobs:
           -Dsonar.exclusions=clients/vscode-hlasmplugin/src/test/**
           -Dsonar.test.inclusions=clients/vscode-hlasmplugin/src/test/**
           -Dsonar.coverage.exclusions=benchmark/benchmark.cpp
-          ${{ env.HEAD_BRANCH }}
-          ${{ env.PR_NUMBER }}
+          $(cat pr-info/head-branch-arg.txt)
+          $(cat pr-info/pr-number-arg.txt)

--- a/.github/workflows/Sonarcloud-scan.yml
+++ b/.github/workflows/Sonarcloud-scan.yml
@@ -69,8 +69,8 @@ jobs:
           export PATH=$SONAR_SCANNER_HOME/bin:$PATH &&
           export SONAR_SCANNER_OPTS="-server" &&
           sonar-scanner
-          -Dsonar.projectKey=michalbali256_che-che4z-lsp-for-hlasm
-          -Dsonar.organization=michalbali256
+          -Dsonar.projectKey=eclipse_che-che4z-lsp-for-hlasm
+          -Dsonar.organization=eclipse
           -Dsonar.sources=benchmark,clients/vscode-hlasmplugin/src/,language_server/src,parser_library/src,parser_library/include,build/generated_parser/
           -Dsonar.tests=parser_library/test,language_server/test,clients/vscode-hlasmplugin/src/test
           -Dsonar.host.url=https://sonarcloud.io

--- a/.github/workflows/Sonarcloud-scan.yml
+++ b/.github/workflows/Sonarcloud-scan.yml
@@ -69,8 +69,8 @@ jobs:
           export PATH=$SONAR_SCANNER_HOME/bin:$PATH &&
           export SONAR_SCANNER_OPTS="-server" &&
           sonar-scanner
-          -Dsonar.projectKey=eclipse_che-che4z-lsp-for-hlasm
-          -Dsonar.organization=eclipse
+          -Dsonar.projectKey=michalbali256_che-che4z-lsp-for-hlasm
+          -Dsonar.organization=michalbali256
           -Dsonar.sources=benchmark,clients/vscode-hlasmplugin/src/,language_server/src,parser_library/src,parser_library/include,build/generated_parser/
           -Dsonar.tests=parser_library/test,language_server/test,clients/vscode-hlasmplugin/src/test
           -Dsonar.host.url=https://sonarcloud.io

--- a/.github/workflows/Sonarcloud-scan.yml
+++ b/.github/workflows/Sonarcloud-scan.yml
@@ -77,9 +77,9 @@ jobs:
           -Dsonar.login=${{ secrets.SONAR_TOKEN }}
           -Dsonar.cfamily.build-wrapper-output=build/bw-output
           -Dsonar.cfamily.threads=4
-          -Dsonar.cfamily.llvm-cov.reportPath=build/bin/coverage.txt
+          -Dsonar.cfamily.llvm-cov.reportPath=build/coverage.txt
           -Dsonar.cfamily.cache.enabled=false
-          -Dsonar.typescript.lcov.reportPaths=clients/vscode-hlasmplugin/coverage/lcov.info
+          -Dsonar.javascript.lcov.reportPaths=clients/vscode-hlasmplugin/coverage/lcov.info
           -Dsonar.projectVersion=${{ env.VERSION }}
           -Dsonar.cpd.exclusions=parser_library/src/context/instruction.cpp
           -Dsonar.exclusions=clients/vscode-hlasmplugin/src/test/**

--- a/.github/workflows/Sonarcloud-scan.yml
+++ b/.github/workflows/Sonarcloud-scan.yml
@@ -27,6 +27,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: 'Download build output'
         uses: actions/github-script@v3.1.0
         with:

--- a/.github/workflows/Sonarcloud-scan.yml
+++ b/.github/workflows/Sonarcloud-scan.yml
@@ -12,7 +12,7 @@
 #   Broadcom, Inc. - initial API and implementation
 #
 
-name: SonarCloud
+name: SonarCloud scan
 
 on:
   workflow_run:
@@ -22,7 +22,7 @@ on:
 
 jobs:
   sonar:
-    name: Sonar scan
+    name: SonarCloud scan
     runs-on: ubuntu-18.04
 
     steps:
@@ -39,7 +39,7 @@ jobs:
                run_id: ${{github.event.workflow_run.id }},
             });
             var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
-              return artifact.name == "bw_output"
+              return artifact.name == "bw-output"
             })[0];
             var download = await github.actions.downloadArtifact({
                owner: context.repo.owner,


### PR DESCRIPTION
Sonarcloud workflow is now split into two workflows:  
- Unpriviliged part, that builds the project and produces coverage
- Priviliged part that uses repository secrets to do the sonarcloud scan and upload the results.

See https://securitylab.github.com/research/github-actions-preventing-pwn-requests for more info.

This PR also fixes a problem with typescript coverage - option sonar.typescript.lcov.reportPaths is deprecated.

It is necessary to merge this PR directly into master, because `workflow_run` workflows are started only from the main branch of repository.