### PR TITLE
chore: Fix the workflow 'SonarCloud scan'

### DIFF
--- a/.github/workflows/Sonarcloud-build.yml
+++ b/.github/workflows/Sonarcloud-build.yml
@@ -64,13 +64,19 @@ jobs:
         run: cd build/bin && llvm-profdata-8 merge -o hlasm_profile library.rawprof server.rawprof
       - name: Generate lcov coverage
         run: cd build/bin && llvm-cov-8 show -instr-profile hlasm_profile library_test -object server_test > ../coverage.txt
-      - name: Pull request setting
+      - name: Pull request event info
         if: github.event_name == 'pull_request'
         run: |
           mkdir pr-info
           echo $(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH") > pr-info/pr-number.txt
+          echo refs/pull/$(cat pr-info/pr-number.txt)/merge > pr-info/ref.txt
           echo -Dsonar.pullrequest.key=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH") > pr-info/pr-number-arg.txt
           echo -Dsonar.pullrequest.branch=${{ github.head_ref }} > pr-info/head-branch-arg.txt
+      - name: Push event info
+        if: github.event_name == 'push'
+        run: |
+          mkdir pr-info
+          echo ${{ github.event.ref }} > pr-info/ref.txt
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/Sonarcloud-scan.yml
+++ b/.github/workflows/Sonarcloud-scan.yml
@@ -24,11 +24,9 @@ jobs:
   sonar:
     name: SonarCloud scan
     runs-on: ubuntu-18.04
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
       - name: 'Download build output'
         uses: actions/github-script@v3.1.0
         with:
@@ -50,8 +48,15 @@ jobs:
             var fs = require('fs');
             fs.writeFileSync('${{github.workspace}}/bw-artifact.zip', Buffer.from(download.data));
       - run: unzip bw-artifact.zip
-      
-      
+      - name: Get ref
+        run: echo "REF=$(cat pr-info/ref.txt)" >> $GITHUB_ENV
+      - run: mv bw-artifact.zip /tmp/bw-artifact.zip
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          ref: ${{ env.REF }}
+      - run: mv /tmp/bw-artifact.zip bw-artifact.zip
+      - run: unzip bw-artifact.zip
       - name: Get version
         run: echo "VERSION=$(node -e "console.log(require('./clients/vscode-hlasmplugin/package.json').version)")" >> $GITHUB_ENV
 


### PR DESCRIPTION
Fixes a problem with SonarCloud scan which checkouts wrong branch in the current version, causing failure of sonar scanner.

The new version passes information about the correct branch from the `SonarCloud build` workflow to the `SonarCloud scan`