### PR TITLE
feat: UI enhancement for the WASM server variant

### DIFF
--- a/clients/vscode-hlasmplugin/package.json
+++ b/clients/vscode-hlasmplugin/package.json
@@ -348,6 +348,11 @@
             "tcp",
             "wasm"
           ]
+        },
+        "hlasm.useAutodetection": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enables autodetection of HLASM source code for automatic setting of Language Mode."
         }
       }
     }

--- a/clients/vscode-hlasmplugin/package.json
+++ b/clients/vscode-hlasmplugin/package.json
@@ -339,7 +339,7 @@
           "default": 10,
           "description": "This option limits number of diagnostics shown for an open code when there is no configuration in pgm_conf.json."
         },
-        "hlasm.communicationMethod": {
+        "hlasm.serverVariant": {
           "type": "string",
           "default": "native",
           "description": "Select language server variant - native, wasm, tcp.",

--- a/clients/vscode-hlasmplugin/src/customEditorCommands.ts
+++ b/clients/vscode-hlasmplugin/src/customEditorCommands.ts
@@ -18,7 +18,7 @@ import * as vscode from 'vscode';
  * Overrides text editor commands of VSCode to handle continuations
  */
 export class CustomEditorCommands {
-    dispose() {}
+    dispose() { }
 
     /**
      * Overriden cut to handle continuations
@@ -64,9 +64,9 @@ export class CustomEditorCommands {
             editor.selection.active.character - ((selectionSize >= -1) ? selectionSize : 0));
 
         // there is a continuation and it is after our position, handle it
-        if (isLineContinued(editor.document,editor.selection.active.line, continuationOffset) && 
-        editor.selection.active.character < continuationOffset && 
-        editor.selection.isSingleLine) {
+        if (isLineContinued(editor.document, editor.selection.active.line, continuationOffset) &&
+            editor.selection.active.character < continuationOffset &&
+            editor.selection.isSingleLine) {
             const beforeContinuationChars =
                 new vscode.Range(editor.selection.active.line,
                     continuationOffset - Math.abs(selectionSize),
@@ -94,7 +94,7 @@ export class CustomEditorCommands {
      * @param editor 
      * @param edit 
      */
-    insertChars(editor: vscode.TextEditor, edit: vscode.TextEditorEdit, args: {text: string}, continuationOffset: number) {
+    insertChars(editor: vscode.TextEditor, edit: vscode.TextEditorEdit, args: { text: string }, continuationOffset: number) {
         // typing with multiple characters selected
         if (editor.selection.active.line != editor.selection.anchor.line || editor.selection.active.character != editor.selection.anchor.character) {
             //simulate delete function for the selected characters
@@ -117,7 +117,7 @@ export class CustomEditorCommands {
         // there is a continuation, prepare space for new characters
         if (continuationOffset && editor.selection.active.character < continuationOffset) {
             // find free space in front of it
-            const spaceRange = this.findSpace(editor.document.lineAt(editor.selection.active), args.text.length, editor,continuationOffset);
+            const spaceRange = this.findSpace(editor.document.lineAt(editor.selection.active), args.text.length, editor, continuationOffset);
             // if there is, delete it
             if (spaceRange)
                 edit.delete(spaceRange);
@@ -144,9 +144,9 @@ export class CustomEditorCommands {
                 : editor.selection.active.character;
 
         // there is a continuation and it is after our position, handle it
-        if (isLineContinued(editor.document,editor.selection.active.line, continuationOffset) && 
-            endPos < continuationOffset && 
-            (editor.selection.active.character > 0 || selectionSize > 0) && 
+        if (isLineContinued(editor.document, editor.selection.active.line, continuationOffset) &&
+            endPos < continuationOffset &&
+            (editor.selection.active.character > 0 || selectionSize > 0) &&
             editor.selection.isSingleLine) {
             const beforeContinuationChars = new vscode.Range(
                 editor.selection.active.line, continuationOffset - Math.abs(selectionSize),
@@ -195,5 +195,6 @@ export function isLineContinued(document: vscode.TextDocument, line: number, off
         return false;
     const continuationPosition = new vscode.Position(line, offset);
     return document.validatePosition(continuationPosition) == continuationPosition &&
+        offset < document.lineAt(line).text.length &&
         document.lineAt(line).text[offset] != " ";
 }

--- a/clients/vscode-hlasmplugin/src/eventsHandler.ts
+++ b/clients/vscode-hlasmplugin/src/eventsHandler.ts
@@ -35,8 +35,7 @@ export class EventsHandler {
      * @param completeCommand Used to invoke complete manually in continuationHandling mode
      * @param highlight Shows/hides parsing progress
      */
-    constructor(completeCommand: string, highlight: SemanticTokensFeature)
-    {
+    constructor(completeCommand: string, highlight: SemanticTokensFeature) {
         this.isInstruction = new RegExp("^([^*][^*]\\S*\\s+\\S+|\\s+\\S*)$");
         this.isTrigger = new RegExp("^[a-zA-Z\*\@\#\$\_]+$");
         this.completeCommand = completeCommand;
@@ -45,11 +44,10 @@ export class EventsHandler {
         this.initialize(highlight);
     }
 
-    dispose() {}
+    dispose() { }
 
     // invoked on extension activation
-    private initialize(highlight: SemanticTokensFeature)
-    {
+    private initialize(highlight: SemanticTokensFeature) {
         // initialize wildcards
         this.configSetup.updateWildcards();
         // first run, simulate ondidopen
@@ -75,8 +73,8 @@ export class EventsHandler {
                 new vscode.Range(
                     new vscode.Position(
                         change.range.start.line, 0),
-                        change.range.start));
-                        
+                    change.range.start));
+
             const notContinued = change.range.start.line == 0 ||
                 !isLineContinued(event.document, change.range.start.line, continuationOffset);
 
@@ -137,7 +135,7 @@ export class EventsHandler {
  * @param option name of the option (e.g. for hlasmplugin.path should be path)
  * @param defaultValue default value to return if option is not set
  */
-export function getConfig<T>(option: string, defaultValue?: any): T {
+export function getConfig<T>(option: string, defaultValue?: T): T {
     const config = vscode.workspace.getConfiguration('hlasm');
     return config.get<T>(option, defaultValue);
 }

--- a/clients/vscode-hlasmplugin/src/hlasmLanguageDetection.ts
+++ b/clients/vscode-hlasmplugin/src/hlasmLanguageDetection.ts
@@ -15,6 +15,7 @@
 import * as vscode from 'vscode';
 
 import { ConfigurationsHandler } from './configurationsHandler'
+import { getConfig } from './eventsHandler';
 
 /**
  * Runs automatic HLASM language detection on given files
@@ -53,6 +54,9 @@ export class HLASMLanguageDetection {
 
         const text = document.getText();
         if (text.length == 0)
+            return false;
+
+        if (!getConfig<boolean>('useAutodetection', false))
             return false;
 
         var score = 0;

--- a/clients/vscode-hlasmplugin/src/serverFactory.ts
+++ b/clients/vscode-hlasmplugin/src/serverFactory.ts
@@ -17,9 +17,8 @@ import * as net from 'net';
 import * as cp from 'child_process'
 import * as path from 'path'
 import { getConfig } from './eventsHandler'
-import { SourceBreakpoint } from 'vscode';
 
-export type ServerCommunicationMethod = "tcp" | "native" | "wasm";
+export type ServerVariant = "tcp" | "native" | "wasm";
 
 /**
  * factory to create server options
@@ -32,7 +31,7 @@ export class ServerFactory {
         this.usedPorts = new Set();
     }
 
-    async create(method: ServerCommunicationMethod): Promise<vscodelc.ServerOptions> {
+    async create(method: ServerVariant): Promise<vscodelc.ServerOptions> {
         const langServerFolder = process.platform;
         if (method === 'tcp') {
             const lspPort = await this.getPort();

--- a/clients/vscode-hlasmplugin/src/test/workspace/.vscode/settings.native.json
+++ b/clients/vscode-hlasmplugin/src/test/workspace/.vscode/settings.native.json
@@ -1,3 +1,4 @@
 {
-    "hlasm.continuationHandling": true
+    "hlasm.continuationHandling": true,
+    "hlasm.useAutodetection": true
 }

--- a/clients/vscode-hlasmplugin/src/test/workspace/.vscode/settings.wasm.json
+++ b/clients/vscode-hlasmplugin/src/test/workspace/.vscode/settings.wasm.json
@@ -1,4 +1,4 @@
 {
     "hlasm.continuationHandling": true,
-    "hlasm.communicationMethod": "wasm"
+    "hlasm.serverVariant": "wasm"
 }

--- a/clients/vscode-hlasmplugin/src/test/workspace/.vscode/settings.wasm.json
+++ b/clients/vscode-hlasmplugin/src/test/workspace/.vscode/settings.wasm.json
@@ -1,4 +1,5 @@
 {
     "hlasm.continuationHandling": true,
+    "hlasm.useAutodetection": true,
     "hlasm.serverVariant": "wasm"
 }


### PR DESCRIPTION
- Introduces a time-based check for native server start, suggests switch to WASM on failure (the assumption being that the server binary was blocked by AV).
- Tweaks the continuation helper commands.