### PR TITLE
fix: AREAD/AINSERT support in macros called from copybooks

### DIFF
--- a/clients/vscode-hlasmplugin/src/test/runTest.ts
+++ b/clients/vscode-hlasmplugin/src/test/runTest.ts
@@ -22,7 +22,7 @@ async function main() {
 		// prepare development and tests paths
 		const extensionDevelopmentPath = path.join(__dirname, '../../');
 		const extensionTestsPath = path.join(__dirname, './suite/index');
-		const launchArgs = [path.join(__dirname, './workspace/'), '--disable-extensions'];
+		const launchArgs = [path.join(__dirname, './workspace/'), '--disable-extensions', '--disable-workspace-trust'];
 		var options: TestOptions;
 		if (process.argv.length > 2 && process.argv[2] == 'insiders') {
 			const vscodeExecutablePath = await downloadAndUnzipVSCode('insiders');

--- a/language_server/src/feature.cpp
+++ b/language_server/src/feature.cpp
@@ -110,8 +110,9 @@ parser_library::range feature::parse_range(const json& range_json)
 
 parser_library::position feature::parse_position(const json& position_json)
 {
-    return { position_json["line"].get<nlohmann::json::number_unsigned_t>(),
-        position_json["character"].get<nlohmann::json::number_unsigned_t>() };
+    // TODO: rewrite message parsing
+    return { (size_t)position_json["line"].get<nlohmann::json::number_unsigned_t>(),
+        (size_t)position_json["character"].get<nlohmann::json::number_unsigned_t>() };
 }
 
 json feature::range_to_json(const parser_library::range& range)

--- a/parser_library/fuzzer/fuzzer.cpp
+++ b/parser_library/fuzzer/fuzzer.cpp
@@ -12,44 +12,75 @@
  *   Broadcom, Inc. - initial API and implementation
  */
 
+#include <charconv>
 #include <cstring>
+#include <optional>
 #include <string>
 
 #include "analyzer.h"
 #include "workspaces/file_impl.h"
+#include "workspaces/parse_lib_provider.h"
 
 using namespace hlasm_plugin::parser_library;
+using namespace hlasm_plugin::parser_library::workspaces;
+
+
+
+class fuzzer_lib_provider : public parse_lib_provider
+{
+    std::optional<size_t> read_library_name(const std::string& library) const
+    {
+        if (library.size() < 2 || library.size() > 8 || library[0] != '@'
+            || std::any_of(library.begin() + 1, library.end(), [](unsigned char c) { return !isdigit(c); }))
+            return std::nullopt;
+
+        size_t result;
+        std::from_chars(library.data() + 1, library.data() + library.size(), result);
+        if (result >= files.size())
+            return std::nullopt;
+
+        return result;
+    }
+
+public:
+    parse_result parse_library(const std::string& library, analyzing_context ctx, library_data data) override
+    {
+        auto lib = read_library_name(library);
+        if (!lib.has_value())
+            return false;
+
+        auto a =
+            std::make_unique<analyzer>(files[lib.value()], analyzer_options { library, this, std::move(ctx), data });
+        a->analyze();
+        a->collect_diags();
+        return true;
+    }
+
+    bool has_library(const std::string& library, const std::string&) const override
+    {
+        return read_library_name(library).has_value();
+    }
+
+    std::vector<std::string> files;
+};
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
     std::string source;
-    source.resize(size);
-    memcpy((void*)source.data(), data, size);
+    std::string* target = &source;
+    fuzzer_lib_provider lib;
 
-    for (char c : source)
+    while (auto next = (const uint8_t*)memchr(data, 0xff, size))
     {
-        if (c <= 8 || c == '\t' || c == 11 || c == 12 || (c >= 14 && c < 32) || c >= 127)
-        {
-            // std::cout << "invalid char\n";
-            return 0;
-        }
+        *target = workspaces::file_impl::replace_non_utf8_chars(std::string_view((const char*)data, next - data));
+
+        target = &lib.files.emplace_back();
+        size -= next + 1 - data;
+        data = next + 1;
     }
+    *target = workspaces::file_impl::replace_non_utf8_chars(std::string_view((const char*)data, size));
 
-    source = workspaces::file_impl::replace_non_utf8_chars(source);
-
-    try
-    {
-        auto s = antlrcpp::utf8_to_utf32((char*)data, (char*)(data + size));
-    }
-    catch (...)
-    {
-        // std::cout << "invalid UTF8\n";
-        return 0;
-    }
-
-    // std::cout << "BEGINBEGIN\n" << source << "ENDEND\n";
-
-    analyzer a(source);
+    analyzer a(source, analyzer_options(&lib));
     a.analyze();
 
     return 0; // Non-zero return values are reserved for future use.

--- a/parser_library/include/range.h
+++ b/parser_library/include/range.h
@@ -24,22 +24,20 @@
 
 namespace hlasm_plugin::parser_library {
 
-using position_t = uint64_t;
-
 struct PARSER_LIBRARY_EXPORT position
 {
     position()
         : line(0)
         , column(0)
     {}
-    position(position_t line, position_t column)
+    position(size_t line, size_t column)
         : line(line)
         , column(column)
     {}
     bool operator==(const position& oth) const { return line == oth.line && column == oth.column; }
     bool operator!=(const position& oth) const { return !(*this == oth); }
-    position_t line;
-    position_t column;
+    size_t line;
+    size_t column;
 
     static inline position min(const position& lhs, const position& rhs)
     {

--- a/parser_library/src/context/copy_member.h
+++ b/parser_library/src/context/copy_member.h
@@ -48,16 +48,16 @@ struct copy_member
 // structure represents invocation of COPY member in HLASM macro library
 struct copy_member_invocation
 {
-    const id_index name;
-    cached_block& cached_definition;
-    const location& definition_location;
-    const copy_member_ptr copy_member_definition;
+    id_index name;
+    cached_block* cached_definition;
+    const location* definition_location;
+    copy_member_ptr copy_member_definition;
     int current_statement;
 
     explicit copy_member_invocation(copy_member_ptr copy_member)
         : name(copy_member->name)
-        , cached_definition(copy_member->cached_definition)
-        , definition_location(copy_member->definition_location)
+        , cached_definition(&copy_member->cached_definition)
+        , definition_location(&copy_member->definition_location)
         , copy_member_definition(std::move(copy_member))
         , current_statement(-1)
     {}

--- a/parser_library/src/context/hlasm_context.cpp
+++ b/parser_library/src/context/hlasm_context.cpp
@@ -347,8 +347,8 @@ processing_stack_t hlasm_context::processing_stack() const
         res.emplace_back(source_stack_[i].current_instruction, scope_stack_.front(), file_processing_type::OPENCODE);
         for (const auto& member : source_stack_[i].copy_stack)
         {
-            location loc(member.cached_definition[member.current_statement].get_base()->statement_position(),
-                member.definition_location.file);
+            location loc(member.cached_definition->at(member.current_statement).get_base()->statement_position(),
+                member.definition_location->file);
             res.emplace_back(std::move(loc), scope_stack_.front(), file_processing_type::COPY);
         }
 
@@ -377,8 +377,8 @@ location hlasm_context::current_statement_location() const
         {
             const auto& member = source_stack_.back().copy_stack.back();
 
-            auto pos = member.cached_definition[member.current_statement].get_base()->statement_position();
-            return location(pos, member.definition_location.file);
+            auto pos = member.cached_definition->at(member.current_statement).get_base()->statement_position();
+            return location(pos, member.definition_location->file);
         }
         else
             return source_stack_.back().current_instruction;

--- a/parser_library/src/context/hlasm_context.cpp
+++ b/parser_library/src/context/hlasm_context.cpp
@@ -402,6 +402,12 @@ const std::vector<copy_member_invocation>& hlasm_context::current_copy_stack() c
 
 std::vector<copy_member_invocation>& hlasm_context::current_copy_stack() { return source_stack_.back().copy_stack; }
 
+const std::vector<copy_member_invocation>&
+hlasm_plugin::parser_library::context::hlasm_context::opencode_copy_stack() const
+{
+    return source_stack_.front().copy_stack;
+}
+
 std::vector<copy_member_invocation>& hlasm_plugin::parser_library::context::hlasm_context::opencode_copy_stack()
 {
     return source_stack_.front().copy_stack;

--- a/parser_library/src/context/hlasm_context.cpp
+++ b/parser_library/src/context/hlasm_context.cpp
@@ -402,7 +402,7 @@ const std::vector<copy_member_invocation>& hlasm_context::current_copy_stack() c
 
 std::vector<copy_member_invocation>& hlasm_context::current_copy_stack() { return source_stack_.back().copy_stack; }
 
-std::vector<copy_member_invocation>& hlasm_plugin::parser_library::context::hlasm_context::top_level_copy_stack()
+std::vector<copy_member_invocation>& hlasm_plugin::parser_library::context::hlasm_context::opencode_copy_stack()
 {
     return source_stack_.front().copy_stack;
 }

--- a/parser_library/src/context/hlasm_context.cpp
+++ b/parser_library/src/context/hlasm_context.cpp
@@ -402,6 +402,11 @@ const std::vector<copy_member_invocation>& hlasm_context::current_copy_stack() c
 
 std::vector<copy_member_invocation>& hlasm_context::current_copy_stack() { return source_stack_.back().copy_stack; }
 
+std::vector<copy_member_invocation>& hlasm_plugin::parser_library::context::hlasm_context::top_level_copy_stack()
+{
+    return source_stack_.front().copy_stack;
+}
+
 std::vector<id_index> hlasm_context::whole_copy_stack() const
 {
     std::vector<id_index> ret;

--- a/parser_library/src/context/hlasm_context.h
+++ b/parser_library/src/context/hlasm_context.h
@@ -116,7 +116,8 @@ public:
     // gets copy nest of current statement processing
     const std::vector<copy_member_invocation>& current_copy_stack() const;
     std::vector<copy_member_invocation>& current_copy_stack();
-    // gets top level copy stack
+    // gets top level (opencode) copy stack
+    const std::vector<copy_member_invocation>& opencode_copy_stack() const;
     std::vector<copy_member_invocation>& opencode_copy_stack();
     // gets names of whole copy nest
     std::vector<id_index> whole_copy_stack() const;

--- a/parser_library/src/context/hlasm_context.h
+++ b/parser_library/src/context/hlasm_context.h
@@ -117,7 +117,7 @@ public:
     const std::vector<copy_member_invocation>& current_copy_stack() const;
     std::vector<copy_member_invocation>& current_copy_stack();
     // gets top level copy stack
-    std::vector<copy_member_invocation>& top_level_copy_stack();
+    std::vector<copy_member_invocation>& opencode_copy_stack();
     // gets names of whole copy nest
     std::vector<id_index> whole_copy_stack() const;
 

--- a/parser_library/src/context/hlasm_context.h
+++ b/parser_library/src/context/hlasm_context.h
@@ -116,6 +116,8 @@ public:
     // gets copy nest of current statement processing
     const std::vector<copy_member_invocation>& current_copy_stack() const;
     std::vector<copy_member_invocation>& current_copy_stack();
+    // gets top level copy stack
+    std::vector<copy_member_invocation>& top_level_copy_stack();
     // gets names of whole copy nest
     std::vector<id_index> whole_copy_stack() const;
 

--- a/parser_library/src/debugging/debug_types.h
+++ b/parser_library/src/debugging/debug_types.h
@@ -37,15 +37,15 @@ struct source
 
 struct stack_frame
 {
-    stack_frame(position_t begin_line, position_t end_line, uint32_t id, std::string name, source source)
+    stack_frame(size_t begin_line, size_t end_line, uint32_t id, std::string name, source source)
         : begin_line(begin_line)
         , end_line(end_line)
         , id(id)
         , name(std::move(name))
         , frame_source(std::move(source))
     {}
-    position_t begin_line;
-    position_t end_line;
+    size_t begin_line;
+    size_t end_line;
     uint32_t id;
     std::string name;
     source frame_source;

--- a/parser_library/src/lsp/lsp_context.cpp
+++ b/parser_library/src/lsp/lsp_context.cpp
@@ -197,7 +197,7 @@ bool lsp_context::should_complete_instr(const text_data_ref_t& text, const posit
 {
     bool line_before_continued = pos.line > 0 ? is_continued_line(text.get_line(pos.line - 1)) : false;
 
-    std::string_view line_so_far = text.get_line_beginning(pos);
+    std::string_view line_so_far = text.get_line_beginning_at(pos);
 
     static const std::regex instruction_regex("^([^*][^*]\\S*\\s+\\S+|\\s+\\S*)");
     return !line_before_continued && std::regex_match(line_so_far.begin(), line_so_far.end(), instruction_regex);

--- a/parser_library/src/lsp/lsp_context.cpp
+++ b/parser_library/src/lsp/lsp_context.cpp
@@ -120,6 +120,14 @@ macro_info_ptr lsp_context::get_macro_info(context::id_index macro_name) const
         return macros_.at(it->second);
 }
 
+const file_info* lsp_context::get_file_info(const std::string& file_name) const
+{
+    if (auto it = files_.find(file_name); it != files_.end())
+        return it->second.get();
+    else
+        return nullptr;
+}
+
 location lsp_context::definition(const std::string& document_uri, const position pos) const
 {
     auto [occ, macro_scope] = find_occurence_with_scope(document_uri, pos);

--- a/parser_library/src/lsp/lsp_context.h
+++ b/parser_library/src/lsp/lsp_context.h
@@ -35,6 +35,7 @@ public:
     void add_opencode(opencode_info_ptr opencode_i, text_data_ref_t text_data);
 
     [[nodiscard]] macro_info_ptr get_macro_info(context::id_index macro_name) const;
+    [[nodiscard]] const file_info* get_file_info(const std::string& file_name) const;
 
     location definition(const std::string& document_uri, position pos) const override;
     location_list references(const std::string& document_uri, position pos) const override;

--- a/parser_library/src/lsp/text_data_ref_t.cpp
+++ b/parser_library/src/lsp/text_data_ref_t.cpp
@@ -41,8 +41,6 @@ std::string_view text_data_ref_t::get_line_beginning(position pos) const
     return { &text->at(line_indices[pos.line]), line_len };
 }
 
-
-
 char text_data_ref_t::get_character_before(position pos) const
 {
     if (pos.column == 0)
@@ -58,6 +56,13 @@ std::string_view text_data_ref_t::get_range_content(range r) const
     if (start_i >= text->size())
         return empty_text;
     return std::string_view(&text->at(start_i), end_i - start_i);
+}
+
+std::string_view text_data_ref_t::get_lines_beginning(position pos) const
+{
+    if (pos.line >= line_indices.size())
+        return {};
+    return std::string_view(*text).substr(line_indices[pos.line]);
 }
 
 size_t text_data_ref_t::get_number_of_lines() const { return line_indices.size(); }

--- a/parser_library/src/lsp/text_data_ref_t.cpp
+++ b/parser_library/src/lsp/text_data_ref_t.cpp
@@ -32,7 +32,7 @@ std::string_view text_data_ref_t::get_line(size_t line) const
     return { &text->at(line_indices[line]), line_len };
 }
 
-std::string_view text_data_ref_t::get_line_beginning(position pos) const
+std::string_view text_data_ref_t::get_line_beginning_at(position pos) const
 {
     if (pos.line >= line_indices.size())
         return "";
@@ -58,7 +58,7 @@ std::string_view text_data_ref_t::get_range_content(range r) const
     return std::string_view(&text->at(start_i), end_i - start_i);
 }
 
-std::string_view text_data_ref_t::get_lines_beginning(position pos) const
+std::string_view text_data_ref_t::get_lines_beginning_at(position pos) const
 {
     if (pos.line >= line_indices.size())
         return {};

--- a/parser_library/src/lsp/text_data_ref_t.h
+++ b/parser_library/src/lsp/text_data_ref_t.h
@@ -43,6 +43,9 @@ public:
     // Returns a string_view beginning at specified position and ending at specified position
     std::string_view get_range_content(range pos) const;
 
+    // Returns a string_view beginning at specified line
+    std::string_view get_lines_beginning(position pos) const;
+
     // Returns a character before the specified position
     // If the position points to the first character, returns '\0'
     char get_character_before(position pos) const;

--- a/parser_library/src/lsp/text_data_ref_t.h
+++ b/parser_library/src/lsp/text_data_ref_t.h
@@ -38,13 +38,13 @@ public:
     std::string_view get_line(size_t line) const;
 
     // Returns a string_view beginning at specified line and ending at specified column
-    std::string_view get_line_beginning(position pos) const;
+    std::string_view get_line_beginning_at(position pos) const;
 
     // Returns a string_view beginning at specified position and ending at specified position
     std::string_view get_range_content(range pos) const;
 
     // Returns a string_view beginning at specified line
-    std::string_view get_lines_beginning(position pos) const;
+    std::string_view get_lines_beginning_at(position pos) const;
 
     // Returns a character before the specified position
     // If the position points to the first character, returns '\0'

--- a/parser_library/src/processing/opencode_provider.cpp
+++ b/parser_library/src/processing/opencode_provider.cpp
@@ -61,7 +61,7 @@ void opencode_provider::rewind_input(context::source_position pos)
     m_current_line = pos.file_line;
 }
 
-void opencode_provider::generate_aread_highlighting(std::string_view text, position_t line_no) const
+void opencode_provider::generate_aread_highlighting(std::string_view text, size_t line_no) const
 {
     if (text.empty())
         return;
@@ -684,7 +684,7 @@ void opencode_provider::suspend_copy()
     m_copy_suspended = true;
 }
 
-bool opencode_provider::resume_copy(position_t line_no, processing::resume_copy resume_opts)
+bool opencode_provider::resume_copy(size_t line_no, processing::resume_copy resume_opts)
 {
     if (m_state_listener->resume_opencode_copy_processing_at(line_no, resume_opts))
     {

--- a/parser_library/src/processing/opencode_provider.cpp
+++ b/parser_library/src/processing/opencode_provider.cpp
@@ -581,7 +581,11 @@ extract_next_logical_line_result opencode_provider::extract_next_logical_line()
             if (m_copy_files.empty())
                 resume_copy(0, resume_copy::ignore_line);
             else if (resume_copy(m_copy_files.back().line_no, resume_copy::exact_line_match))
+            {
+                // copy processing was resumed, pre-parsed statements will be executed
+                m_copy_files.clear();
                 return extract_next_logical_line_result::failed;
+            }
         }
     }
 

--- a/parser_library/src/processing/opencode_provider.cpp
+++ b/parser_library/src/processing/opencode_provider.cpp
@@ -351,13 +351,14 @@ bool opencode_provider::fill_copy_buffer_for_aread()
         const auto pos = copy.cached_definition->at(copy.current_statement).get_base()->statement_position();
         const auto* const copy_content = lsp_ctx->get_file_info(copy.definition_location->file);
 
+        std::string_view full_text = copy_content->data.get_lines_beginning_at({ 0, 0 });
         std::string_view remaining_text = copy_content->data.get_lines_beginning_at(pos);
 
         // remove line being processed
         lexing::logical_line ll = {};
         lexing::extract_logical_line(ll, remaining_text, lexing::default_ictl_copy);
 
-        return copy_member_state { remaining_text, pos.line + ll.segments.size(), copy_content };
+        return copy_member_state { remaining_text, full_text, pos.line + ll.segments.size() };
     };
     std::transform(opencode_stack.begin(), opencode_stack.end(), std::back_inserter(m_copy_files), cmi_to_cms);
 
@@ -519,13 +520,12 @@ extract_next_logical_line_result opencode_provider::extract_next_logical_line_fr
     if (!lexing::extract_logical_line(m_current_logical_line, copy_file.text, lexing::default_ictl_copy))
         return extract_next_logical_line_result::failed;
 
-    const auto copy_start = copy_file.copy_file->data.get_lines_beginning_at({ 0, 0 });
     m_current_logical_line_source.begin_line = copy_file.line_no;
     m_current_logical_line_source.end_line = copy_file.line_no + m_current_logical_line.segments.size() - 1;
     m_current_logical_line_source.begin_offset =
-        m_current_logical_line.segments.front().code.data() - copy_start.data();
+        m_current_logical_line.segments.front().code.data() - copy_file.full_text.data();
     m_current_logical_line_source.end_offset =
-        copy_file.text.size() ? copy_file.text.data() - copy_start.data() : copy_start.size();
+        copy_file.text.size() ? copy_file.text.data() - copy_file.full_text.data() : copy_file.full_text.size();
     m_current_logical_line_source.source = logical_line_origin::source_type::copy;
 
     copy_file.line_no += m_current_logical_line.segments.size() - 1;

--- a/parser_library/src/processing/opencode_provider.cpp
+++ b/parser_library/src/processing/opencode_provider.cpp
@@ -139,7 +139,7 @@ void opencode_provider::ainsert(const std::string& rec, ainsert_destination dest
             m_ainsert_buffer.push_front(rec);
             break;
     }
-    // ainsert buffer may contains macro call that will remove code lines from copybooks
+    // ainsert buffer may contain macro call that will remove code lines from copybooks
     // this prevents copybook unwinding
     if (!m_copy_suspended)
         suspend_copy();
@@ -351,7 +351,7 @@ bool opencode_provider::fill_copy_buffer_for_aread()
         const auto pos = copy.cached_definition->at(copy.current_statement).get_base()->statement_position();
         const auto* const copy_content = lsp_ctx->get_file_info(copy.definition_location->file);
 
-        std::string_view remaining_text = copy_content->data.get_lines_beginning(pos);
+        std::string_view remaining_text = copy_content->data.get_lines_beginning_at(pos);
 
         // remove line being processed
         lexing::logical_line ll = {};
@@ -519,7 +519,7 @@ extract_next_logical_line_result opencode_provider::extract_next_logical_line_fr
     if (!lexing::extract_logical_line(m_current_logical_line, copy_file.text, lexing::default_ictl_copy))
         return extract_next_logical_line_result::failed;
 
-    const auto copy_start = copy_file.copy_file->data.get_lines_beginning({ 0, 0 });
+    const auto copy_start = copy_file.copy_file->data.get_lines_beginning_at({ 0, 0 });
     m_current_logical_line_source.begin_line = copy_file.line_no;
     m_current_logical_line_source.end_line = copy_file.line_no + m_current_logical_line.segments.size() - 1;
     m_current_logical_line_source.begin_offset =

--- a/parser_library/src/processing/opencode_provider.cpp
+++ b/parser_library/src/processing/opencode_provider.cpp
@@ -100,7 +100,7 @@ std::string opencode_provider::aread()
         while (!m_copy_files.empty() && m_copy_files.back().text.empty())
         {
             m_copy_files.pop_back();
-            m_ctx->hlasm_ctx->top_level_copy_stack().pop_back();
+            m_ctx->hlasm_ctx->opencode_copy_stack().pop_back();
         }
     }
     else if (!m_preprocessor_buffer.empty())
@@ -335,7 +335,7 @@ std::shared_ptr<const context::hlasm_statement> opencode_provider::process_ordin
 
 bool opencode_provider::fill_copy_buffer_for_aread()
 {
-    auto& opencode_stack = m_ctx->hlasm_ctx->top_level_copy_stack();
+    auto& opencode_stack = m_ctx->hlasm_ctx->opencode_copy_stack();
     if (opencode_stack.empty())
         return false;
 
@@ -364,7 +364,7 @@ bool opencode_provider::fill_copy_buffer_for_aread()
     if (m_copy_files.empty())
         return false;
 
-    m_state_listener->suspend_top_level_copy_processing();
+    m_state_listener->suspend_opencode_copy_processing();
     m_copy_suspend_called = true;
 
     return true;
@@ -514,14 +514,14 @@ extract_next_logical_line_result opencode_provider::extract_next_logical_line()
     {
         m_copy_files_aread_ready = false;
 
-        assert(&m_ctx->hlasm_ctx->current_copy_stack() == &m_ctx->hlasm_ctx->top_level_copy_stack());
+        assert(&m_ctx->hlasm_ctx->current_copy_stack() == &m_ctx->hlasm_ctx->opencode_copy_stack());
 
         if (m_copy_suspend_called)
         {
             m_copy_suspend_called = false;
             if (m_copy_files.empty())
-                m_state_listener->resume_top_level_copy_processing_at(0, resume_copy::ignore_line);
-            else if (m_state_listener->resume_top_level_copy_processing_at(
+                m_state_listener->resume_opencode_copy_processing_at(0, resume_copy::ignore_line);
+            else if (m_state_listener->resume_opencode_copy_processing_at(
                          m_copy_files.back().line_no, resume_copy::exact_line_match))
                 return extract_next_logical_line_result::failed;
         }
@@ -529,7 +529,7 @@ extract_next_logical_line_result opencode_provider::extract_next_logical_line()
 
     if (!m_copy_files.empty())
     {
-        auto& opencode_copy_stack = m_ctx->hlasm_ctx->top_level_copy_stack();
+        auto& opencode_copy_stack = m_ctx->hlasm_ctx->opencode_copy_stack();
         assert(&opencode_copy_stack == &m_ctx->hlasm_ctx->current_copy_stack());
 
         auto& copy_file = m_copy_files.back();
@@ -551,7 +551,7 @@ extract_next_logical_line_result opencode_provider::extract_next_logical_line()
         while (!m_copy_files.empty()
             && (m_copy_files.back().text.empty()
                 || false
-                    == (restarted = m_state_listener->resume_top_level_copy_processing_at(
+                    == (restarted = m_state_listener->resume_opencode_copy_processing_at(
                             m_copy_files.back().line_no, resume_copy::exact_or_next_line))))
         {
             m_copy_files.pop_back();
@@ -559,7 +559,7 @@ extract_next_logical_line_result opencode_provider::extract_next_logical_line()
         }
 
         if (m_copy_files.empty())
-            restarted = m_state_listener->resume_top_level_copy_processing_at(0, resume_copy::ignore_line);
+            restarted = m_state_listener->resume_opencode_copy_processing_at(0, resume_copy::ignore_line);
 
         assert(restarted);
 

--- a/parser_library/src/processing/opencode_provider.cpp
+++ b/parser_library/src/processing/opencode_provider.cpp
@@ -61,7 +61,7 @@ void opencode_provider::rewind_input(context::source_position pos)
     m_current_line = pos.file_line;
 }
 
-void opencode_provider::generate_aread_highlighting(std::string_view text, size_t line_no) const
+void opencode_provider::generate_aread_highlighting(std::string_view text, position_t line_no) const
 {
     if (text.empty())
         return;
@@ -669,7 +669,7 @@ void opencode_provider::suspend_copy()
     m_copy_suspended = true;
 }
 
-bool opencode_provider::resume_copy(size_t line_no, processing::resume_copy resume_opts)
+bool opencode_provider::resume_copy(position_t line_no, processing::resume_copy resume_opts)
 {
     if (m_state_listener->resume_opencode_copy_processing_at(line_no, resume_opts))
     {

--- a/parser_library/src/processing/opencode_provider.h
+++ b/parser_library/src/processing/opencode_provider.h
@@ -153,6 +153,8 @@ private:
     bool is_next_line_ictl() const;
     bool is_next_line_process() const;
     void generate_continuation_error_messages() const;
+    extract_next_logical_line_result extract_next_logical_line_from_ainsert_buffer();
+    extract_next_logical_line_result extract_next_logical_line_from_copy_buffer();
     extract_next_logical_line_result extract_next_logical_line();
     void apply_pending_line_changes();
     const parsing::parser_holder& prepare_operand_parser(const std::string& text,

--- a/parser_library/src/processing/opencode_provider.h
+++ b/parser_library/src/processing/opencode_provider.h
@@ -72,7 +72,7 @@ class opencode_provider final : public diagnosable_impl, public statement_provid
     lines_to_remove m_lines_to_remove = {};
 
     std::string_view m_original_text;
-    position_t m_current_line = 0;
+    size_t m_current_line = 0;
 
     std::string_view m_next_line_text;
 
@@ -81,8 +81,8 @@ class opencode_provider final : public diagnosable_impl, public statement_provid
     {
         size_t begin_offset;
         size_t end_offset;
-        position_t begin_line;
-        position_t end_line;
+        size_t begin_line;
+        size_t end_line;
         enum class source_type
         {
             none,
@@ -99,7 +99,7 @@ class opencode_provider final : public diagnosable_impl, public statement_provid
     {
         std::string_view text;
         std::string_view full_text;
-        position_t line_no;
+        size_t line_no;
     };
 
     std::vector<copy_member_state> m_copy_files;
@@ -149,7 +149,7 @@ private:
     extract_next_logical_line_result feed_line(parsing::parser_holder& p);
     bool is_comment();
     void process_comment();
-    void generate_aread_highlighting(std::string_view text, position_t line_no) const;
+    void generate_aread_highlighting(std::string_view text, size_t line_no) const;
     bool is_next_line_ictl() const;
     bool is_next_line_process() const;
     void generate_continuation_error_messages() const;
@@ -177,7 +177,7 @@ private:
     bool fill_copy_buffer_for_aread();
 
     void suspend_copy();
-    bool resume_copy(position_t line_no, processing::resume_copy resume_opts);
+    bool resume_copy(size_t line_no, processing::resume_copy resume_opts);
 };
 
 } // namespace hlasm_plugin::parser_library::processing

--- a/parser_library/src/processing/opencode_provider.h
+++ b/parser_library/src/processing/opencode_provider.h
@@ -98,8 +98,8 @@ class opencode_provider final : public diagnosable_impl, public statement_provid
     struct copy_member_state
     {
         std::string_view text;
+        std::string_view full_text;
         position_t line_no;
-        const lsp::file_info* copy_file;
     };
 
     std::vector<copy_member_state> m_copy_files;

--- a/parser_library/src/processing/opencode_provider.h
+++ b/parser_library/src/processing/opencode_provider.h
@@ -72,7 +72,7 @@ class opencode_provider final : public diagnosable_impl, public statement_provid
     lines_to_remove m_lines_to_remove = {};
 
     std::string_view m_original_text;
-    size_t m_current_line = 0;
+    position_t m_current_line = 0;
 
     std::string_view m_next_line_text;
 
@@ -81,8 +81,8 @@ class opencode_provider final : public diagnosable_impl, public statement_provid
     {
         size_t begin_offset;
         size_t end_offset;
-        size_t begin_line;
-        size_t end_line;
+        position_t begin_line;
+        position_t end_line;
         enum class source_type
         {
             none,
@@ -98,7 +98,7 @@ class opencode_provider final : public diagnosable_impl, public statement_provid
     struct copy_member_state
     {
         std::string_view text;
-        size_t line_no;
+        position_t line_no;
         const lsp::file_info* copy_file;
     };
 
@@ -149,7 +149,7 @@ private:
     extract_next_logical_line_result feed_line(parsing::parser_holder& p);
     bool is_comment();
     void process_comment();
-    void generate_aread_highlighting(std::string_view text, size_t line_no) const;
+    void generate_aread_highlighting(std::string_view text, position_t line_no) const;
     bool is_next_line_ictl() const;
     bool is_next_line_process() const;
     void generate_continuation_error_messages() const;
@@ -175,7 +175,7 @@ private:
     bool fill_copy_buffer_for_aread();
 
     void suspend_copy();
-    bool resume_copy(size_t line_no, processing::resume_copy resume_opts);
+    bool resume_copy(position_t line_no, processing::resume_copy resume_opts);
 };
 
 } // namespace hlasm_plugin::parser_library::processing

--- a/parser_library/src/processing/opencode_provider.h
+++ b/parser_library/src/processing/opencode_provider.h
@@ -121,7 +121,7 @@ class opencode_provider final : public diagnosable_impl, public statement_provid
 
     bool m_line_fed = false;
     bool m_copy_files_aread_ready = false;
-    bool m_copy_suspend_called = false;
+    bool m_copy_suspended = false;
 
 public:
     // rewinds position in file
@@ -173,6 +173,9 @@ private:
         const range& op_range);
 
     bool fill_copy_buffer_for_aread();
+
+    void suspend_copy();
+    bool resume_copy(size_t line_no, processing::resume_copy resume_opts);
 };
 
 } // namespace hlasm_plugin::parser_library::processing

--- a/parser_library/src/processing/opencode_provider.h
+++ b/parser_library/src/processing/opencode_provider.h
@@ -94,7 +94,15 @@ class opencode_provider final : public diagnosable_impl, public statement_provid
     } m_current_logical_line_source;
 
     std::deque<std::string> m_ainsert_buffer;
-    std::vector<std::string_view> m_copy_files;
+
+    struct copy_member_state
+    {
+        std::string_view text;
+        size_t line_no;
+        const lsp::file_info* copy_file;
+    };
+
+    std::vector<copy_member_state> m_copy_files;
 
     std::vector<std::string> m_preprocessor_buffer;
 
@@ -112,6 +120,8 @@ class opencode_provider final : public diagnosable_impl, public statement_provid
     parsing::parser_error_listener m_listener;
 
     bool m_line_fed = false;
+    bool m_copy_files_aread_ready = false;
+    bool m_copy_suspend_called = false;
 
 public:
     // rewinds position in file
@@ -161,6 +171,8 @@ private:
         semantics::collector& collector,
         const std::optional<std::string>& op_text,
         const range& op_range);
+
+    bool fill_copy_buffer_for_aread();
 };
 
 } // namespace hlasm_plugin::parser_library::processing

--- a/parser_library/src/processing/processing_manager.cpp
+++ b/parser_library/src/processing/processing_manager.cpp
@@ -241,7 +241,7 @@ void processing_manager::suspend_opencode_copy_processing()
     static_cast<copy_statement_provider&>(copy_prov).suspend();
 }
 
-bool processing_manager::resume_opencode_copy_processing_at(position_t line_no, resume_copy resume_opts)
+bool processing_manager::resume_opencode_copy_processing_at(size_t line_no, resume_copy resume_opts)
 {
     auto& copy_prov = **(provs_.end() - 2);
     assert(copy_prov.kind == statement_provider_kind::COPY);

--- a/parser_library/src/processing/processing_manager.cpp
+++ b/parser_library/src/processing/processing_manager.cpp
@@ -233,7 +233,7 @@ void processing_manager::finish_copy_member(copy_processing_result result)
 
 void processing_manager::finish_opencode() { lsp_analyzer_.opencode_finished(); }
 
-void processing_manager::suspend_top_level_copy_processing()
+void processing_manager::suspend_opencode_copy_processing()
 {
     auto& copy_prov = **(provs_.end() - 2);
     assert(copy_prov.kind == statement_provider_kind::COPY);
@@ -241,7 +241,7 @@ void processing_manager::suspend_top_level_copy_processing()
     static_cast<copy_statement_provider&>(copy_prov).suspend();
 }
 
-bool processing_manager::resume_top_level_copy_processing_at(size_t line_no, resume_copy resume_opts)
+bool processing_manager::resume_opencode_copy_processing_at(size_t line_no, resume_copy resume_opts)
 {
     auto& copy_prov = **(provs_.end() - 2);
     assert(copy_prov.kind == statement_provider_kind::COPY);

--- a/parser_library/src/processing/processing_manager.cpp
+++ b/parser_library/src/processing/processing_manager.cpp
@@ -241,7 +241,7 @@ void processing_manager::suspend_opencode_copy_processing()
     static_cast<copy_statement_provider&>(copy_prov).suspend();
 }
 
-bool processing_manager::resume_opencode_copy_processing_at(size_t line_no, resume_copy resume_opts)
+bool processing_manager::resume_opencode_copy_processing_at(position_t line_no, resume_copy resume_opts)
 {
     auto& copy_prov = **(provs_.end() - 2);
     assert(copy_prov.kind == statement_provider_kind::COPY);

--- a/parser_library/src/processing/processing_manager.cpp
+++ b/parser_library/src/processing/processing_manager.cpp
@@ -246,7 +246,7 @@ bool processing_manager::resume_opencode_copy_processing_at(position_t line_no, 
     auto& copy_prov = **(provs_.end() - 2);
     assert(copy_prov.kind == statement_provider_kind::COPY);
 
-    return static_cast<copy_statement_provider&>(copy_prov).resume_at(line_no, resume_opts);
+    return static_cast<copy_statement_provider&>(copy_prov).try_resume_at(line_no, resume_opts);
 }
 
 void processing_manager::start_macro_definition(macrodef_start_data start, std::optional<std::string> file)

--- a/parser_library/src/processing/processing_manager.cpp
+++ b/parser_library/src/processing/processing_manager.cpp
@@ -233,6 +233,22 @@ void processing_manager::finish_copy_member(copy_processing_result result)
 
 void processing_manager::finish_opencode() { lsp_analyzer_.opencode_finished(); }
 
+void processing_manager::suspend_top_level_copy_processing()
+{
+    auto& copy_prov = **(provs_.end() - 2);
+    assert(copy_prov.kind == statement_provider_kind::COPY);
+
+    static_cast<copy_statement_provider&>(copy_prov).suspend();
+}
+
+bool processing_manager::resume_top_level_copy_processing_at(size_t line_no, resume_copy resume_opts)
+{
+    auto& copy_prov = **(provs_.end() - 2);
+    assert(copy_prov.kind == statement_provider_kind::COPY);
+
+    return static_cast<copy_statement_provider&>(copy_prov).resume_at(line_no, resume_opts);
+}
+
 void processing_manager::start_macro_definition(macrodef_start_data start, std::optional<std::string> file)
 {
     if (file)

--- a/parser_library/src/processing/processing_manager.h
+++ b/parser_library/src/processing/processing_manager.h
@@ -79,7 +79,7 @@ private:
     void finish_opencode() override;
 
     void suspend_opencode_copy_processing() override;
-    bool resume_opencode_copy_processing_at(size_t line_no, resume_copy resume_opts) override;
+    bool resume_opencode_copy_processing_at(position_t line_no, resume_copy resume_opts) override;
 
     void start_macro_definition(macrodef_start_data start, std::optional<std::string> file);
 

--- a/parser_library/src/processing/processing_manager.h
+++ b/parser_library/src/processing/processing_manager.h
@@ -79,7 +79,7 @@ private:
     void finish_opencode() override;
 
     void suspend_opencode_copy_processing() override;
-    bool resume_opencode_copy_processing_at(position_t line_no, resume_copy resume_opts) override;
+    bool resume_opencode_copy_processing_at(size_t line_no, resume_copy resume_opts) override;
 
     void start_macro_definition(macrodef_start_data start, std::optional<std::string> file);
 

--- a/parser_library/src/processing/processing_manager.h
+++ b/parser_library/src/processing/processing_manager.h
@@ -78,8 +78,8 @@ private:
     void finish_copy_member(copy_processing_result result) override;
     void finish_opencode() override;
 
-    void suspend_top_level_copy_processing() override;
-    bool resume_top_level_copy_processing_at(size_t line_no, resume_copy resume_opts) override;
+    void suspend_opencode_copy_processing() override;
+    bool resume_opencode_copy_processing_at(size_t line_no, resume_copy resume_opts) override;
 
     void start_macro_definition(macrodef_start_data start, std::optional<std::string> file);
 

--- a/parser_library/src/processing/processing_manager.h
+++ b/parser_library/src/processing/processing_manager.h
@@ -78,6 +78,9 @@ private:
     void finish_copy_member(copy_processing_result result) override;
     void finish_opencode() override;
 
+    void suspend_top_level_copy_processing() override;
+    bool resume_top_level_copy_processing_at(size_t line_no, resume_copy resume_opts) override;
+
     void start_macro_definition(macrodef_start_data start, std::optional<std::string> file);
 
     void jump_in_statements(context::id_index target, range symbol_range) override;

--- a/parser_library/src/processing/processing_state_listener.h
+++ b/parser_library/src/processing/processing_state_listener.h
@@ -42,7 +42,7 @@ public:
     virtual void finish_copy_member(copy_processing_result result) = 0;
 
     virtual void suspend_opencode_copy_processing() = 0;
-    virtual bool resume_opencode_copy_processing_at(position_t line_no, resume_copy resume_opts) = 0;
+    virtual bool resume_opencode_copy_processing_at(size_t line_no, resume_copy resume_opts) = 0;
 
     virtual void finish_opencode() = 0;
 

--- a/parser_library/src/processing/processing_state_listener.h
+++ b/parser_library/src/processing/processing_state_listener.h
@@ -21,6 +21,13 @@
 
 namespace hlasm_plugin::parser_library::processing {
 
+enum class resume_copy
+{
+    ignore_line,
+    exact_line_match,
+    exact_or_next_line,
+};
+
 // interface for listening that a statement processor needs to be started or has finished
 class processing_state_listener
 {
@@ -33,6 +40,9 @@ public:
 
     virtual void start_copy_member(copy_start_data start) = 0;
     virtual void finish_copy_member(copy_processing_result result) = 0;
+
+    virtual void suspend_top_level_copy_processing() = 0;
+    virtual bool resume_top_level_copy_processing_at(size_t line_no, resume_copy resume_opts) = 0;
 
     virtual void finish_opencode() = 0;
 

--- a/parser_library/src/processing/processing_state_listener.h
+++ b/parser_library/src/processing/processing_state_listener.h
@@ -41,8 +41,8 @@ public:
     virtual void start_copy_member(copy_start_data start) = 0;
     virtual void finish_copy_member(copy_processing_result result) = 0;
 
-    virtual void suspend_top_level_copy_processing() = 0;
-    virtual bool resume_top_level_copy_processing_at(size_t line_no, resume_copy resume_opts) = 0;
+    virtual void suspend_opencode_copy_processing() = 0;
+    virtual bool resume_opencode_copy_processing_at(size_t line_no, resume_copy resume_opts) = 0;
 
     virtual void finish_opencode() = 0;
 

--- a/parser_library/src/processing/processing_state_listener.h
+++ b/parser_library/src/processing/processing_state_listener.h
@@ -42,7 +42,7 @@ public:
     virtual void finish_copy_member(copy_processing_result result) = 0;
 
     virtual void suspend_opencode_copy_processing() = 0;
-    virtual bool resume_opencode_copy_processing_at(size_t line_no, resume_copy resume_opts) = 0;
+    virtual bool resume_opencode_copy_processing_at(position_t line_no, resume_copy resume_opts) = 0;
 
     virtual void finish_opencode() = 0;
 

--- a/parser_library/src/processing/statement_processors/macrodef_processor.cpp
+++ b/parser_library/src/processing/statement_processors/macrodef_processor.cpp
@@ -467,8 +467,8 @@ void macrodef_processor::add_correct_copy_nest()
     for (size_t i = initial_copy_nest_; i < hlasm_ctx.current_copy_stack().size(); ++i)
     {
         auto& nest = hlasm_ctx.current_copy_stack()[i];
-        auto pos = nest.cached_definition[nest.current_statement].get_base()->statement_position();
-        result_.nests.back().emplace_back(pos, nest.definition_location.file);
+        auto pos = nest.cached_definition->at(nest.current_statement).get_base()->statement_position();
+        result_.nests.back().emplace_back(pos, nest.definition_location->file);
     }
 
     if (initial_copy_nest_ < hlasm_ctx.current_copy_stack().size())

--- a/parser_library/src/processing/statement_providers/copy_statement_provider.cpp
+++ b/parser_library/src/processing/statement_providers/copy_statement_provider.cpp
@@ -35,7 +35,7 @@ void copy_statement_provider::suspend()
     m_suspended = true;
 }
 
-bool copy_statement_provider::resume_at(size_t line_no, resume_copy resume_opts)
+bool copy_statement_provider::resume_at(position_t line_no, resume_copy resume_opts)
 {
     assert(m_suspended);
 

--- a/parser_library/src/processing/statement_providers/copy_statement_provider.cpp
+++ b/parser_library/src/processing/statement_providers/copy_statement_provider.cpp
@@ -26,7 +26,7 @@ copy_statement_provider::copy_statement_provider(analyzing_context ctx,
 bool copy_statement_provider::finished() const
 {
     return ctx.hlasm_ctx->current_copy_stack().empty()
-        || m_suspended && &ctx.hlasm_ctx->current_copy_stack() == &ctx.hlasm_ctx->top_level_copy_stack();
+        || m_suspended && &ctx.hlasm_ctx->current_copy_stack() == &ctx.hlasm_ctx->opencode_copy_stack();
 }
 
 void copy_statement_provider::suspend()
@@ -46,7 +46,7 @@ bool copy_statement_provider::resume_at(size_t line_no, resume_copy resume_opts)
     }
 
     auto& invo = ctx.hlasm_ctx->current_copy_stack().back();
-    assert(&ctx.hlasm_ctx->top_level_copy_stack().back() == &invo);
+    assert(&ctx.hlasm_ctx->opencode_copy_stack().back() == &invo);
 
     invo.current_statement = -1;
 

--- a/parser_library/src/processing/statement_providers/copy_statement_provider.cpp
+++ b/parser_library/src/processing/statement_providers/copy_statement_provider.cpp
@@ -35,7 +35,7 @@ void copy_statement_provider::suspend()
     m_suspended = true;
 }
 
-bool copy_statement_provider::try_resume_at(position_t line_no, resume_copy resume_opts)
+bool copy_statement_provider::try_resume_at(size_t line_no, resume_copy resume_opts)
 {
     assert(m_suspended);
 

--- a/parser_library/src/processing/statement_providers/copy_statement_provider.cpp
+++ b/parser_library/src/processing/statement_providers/copy_statement_provider.cpp
@@ -35,7 +35,7 @@ void copy_statement_provider::suspend()
     m_suspended = true;
 }
 
-bool copy_statement_provider::resume_at(position_t line_no, resume_copy resume_opts)
+bool copy_statement_provider::try_resume_at(position_t line_no, resume_copy resume_opts)
 {
     assert(m_suspended);
 

--- a/parser_library/src/processing/statement_providers/copy_statement_provider.cpp
+++ b/parser_library/src/processing/statement_providers/copy_statement_provider.cpp
@@ -23,7 +23,57 @@ copy_statement_provider::copy_statement_provider(analyzing_context ctx,
     : members_statement_provider(statement_provider_kind::COPY, std::move(ctx), parser, lib_provider, listener)
 {}
 
-bool copy_statement_provider::finished() const { return ctx.hlasm_ctx->current_copy_stack().empty(); }
+bool copy_statement_provider::finished() const
+{
+    return ctx.hlasm_ctx->current_copy_stack().empty()
+        || m_suspended && &ctx.hlasm_ctx->current_copy_stack() == &ctx.hlasm_ctx->top_level_copy_stack();
+}
+
+void copy_statement_provider::suspend()
+{
+    assert(!m_suspended);
+    m_suspended = true;
+}
+
+bool copy_statement_provider::resume_at(size_t line_no, resume_copy resume_opts)
+{
+    assert(m_suspended);
+
+    if (resume_opts == resume_copy::ignore_line)
+    {
+        m_suspended = false;
+        return true;
+    }
+
+    auto& invo = ctx.hlasm_ctx->current_copy_stack().back();
+    assert(&ctx.hlasm_ctx->top_level_copy_stack().back() == &invo);
+
+    invo.current_statement = -1;
+
+    for (const auto& stmt : *invo.cached_definition)
+    {
+        const auto stmt_line_no = stmt.get_base()->statement_position().line;
+        if (stmt_line_no == line_no)
+        {
+            m_suspended = false;
+            return true;
+        }
+        else if (stmt_line_no > line_no)
+        {
+            switch (resume_opts)
+            {
+                case resume_copy::exact_line_match:
+                    return false;
+                case resume_copy::exact_or_next_line:
+                    m_suspended = false;
+                    return true;
+            }
+        }
+
+        ++invo.current_statement;
+    }
+    return false;
+}
 
 context::statement_cache* copy_statement_provider::get_next()
 {

--- a/parser_library/src/processing/statement_providers/copy_statement_provider.cpp
+++ b/parser_library/src/processing/statement_providers/copy_statement_provider.cpp
@@ -45,12 +45,11 @@ bool copy_statement_provider::resume_at(size_t line_no, resume_copy resume_opts)
         return true;
     }
 
-    auto& invo = ctx.hlasm_ctx->current_copy_stack().back();
-    assert(&ctx.hlasm_ctx->opencode_copy_stack().back() == &invo);
+    auto& opencode_copy_stack = ctx.hlasm_ctx->opencode_copy_stack().back();
 
-    invo.current_statement = -1;
+    opencode_copy_stack.current_statement = -1;
 
-    for (const auto& stmt : *invo.cached_definition)
+    for (const auto& stmt : *opencode_copy_stack.cached_definition)
     {
         const auto stmt_line_no = stmt.get_base()->statement_position().line;
         if (stmt_line_no == line_no)
@@ -70,7 +69,7 @@ bool copy_statement_provider::resume_at(size_t line_no, resume_copy resume_opts)
             }
         }
 
-        ++invo.current_statement;
+        ++opencode_copy_stack.current_statement;
     }
     return false;
 }

--- a/parser_library/src/processing/statement_providers/copy_statement_provider.cpp
+++ b/parser_library/src/processing/statement_providers/copy_statement_provider.cpp
@@ -30,13 +30,13 @@ context::statement_cache* copy_statement_provider::get_next()
     auto& invo = ctx.hlasm_ctx->current_copy_stack().back();
 
     ++invo.current_statement;
-    if ((size_t)invo.current_statement == invo.cached_definition.size())
+    if ((size_t)invo.current_statement == invo.cached_definition->size())
     {
         ctx.hlasm_ctx->leave_copy_member();
         return nullptr;
     }
 
-    return &invo.cached_definition[invo.current_statement];
+    return &invo.cached_definition->at(invo.current_statement);
 }
 
 } // namespace hlasm_plugin::parser_library::processing

--- a/parser_library/src/processing/statement_providers/copy_statement_provider.h
+++ b/parser_library/src/processing/statement_providers/copy_statement_provider.h
@@ -33,7 +33,7 @@ public:
     bool finished() const override;
 
     void suspend();
-    bool resume_at(size_t line_no, resume_copy resume_opts);
+    bool resume_at(position_t line_no, resume_copy resume_opts);
 
 protected:
     context::statement_cache* get_next() override;

--- a/parser_library/src/processing/statement_providers/copy_statement_provider.h
+++ b/parser_library/src/processing/statement_providers/copy_statement_provider.h
@@ -22,6 +22,8 @@ namespace hlasm_plugin::parser_library::processing {
 // statement provider providing statements of copy members
 class copy_statement_provider : public members_statement_provider
 {
+    bool m_suspended = false;
+
 public:
     copy_statement_provider(analyzing_context ctx,
         statement_fields_parser& parser,
@@ -29,6 +31,9 @@ public:
         processing::processing_state_listener& listener);
 
     bool finished() const override;
+
+    void suspend();
+    bool resume_at(size_t line_no, resume_copy resume_opts);
 
 protected:
     context::statement_cache* get_next() override;

--- a/parser_library/src/processing/statement_providers/copy_statement_provider.h
+++ b/parser_library/src/processing/statement_providers/copy_statement_provider.h
@@ -33,7 +33,7 @@ public:
     bool finished() const override;
 
     void suspend();
-    bool try_resume_at(position_t line_no, resume_copy resume_opts);
+    bool try_resume_at(size_t line_no, resume_copy resume_opts);
 
 protected:
     context::statement_cache* get_next() override;

--- a/parser_library/src/processing/statement_providers/copy_statement_provider.h
+++ b/parser_library/src/processing/statement_providers/copy_statement_provider.h
@@ -33,7 +33,7 @@ public:
     bool finished() const override;
 
     void suspend();
-    bool resume_at(position_t line_no, resume_copy resume_opts);
+    bool try_resume_at(position_t line_no, resume_copy resume_opts);
 
 protected:
     context::statement_cache* get_next() override;

--- a/parser_library/src/workspaces/file_impl.cpp
+++ b/parser_library/src/workspaces/file_impl.cpp
@@ -274,7 +274,7 @@ size_t file_impl::index_from_position(const std::string& text, const std::vector
     return i;
 }
 
-std::string file_impl::replace_non_utf8_chars(const std::string& text)
+std::string file_impl::replace_non_utf8_chars(std::string_view text)
 {
     std::string ret;
     ret.reserve(text.size());
@@ -305,6 +305,14 @@ std::string file_impl::replace_non_utf8_chars(const std::string& text)
                     break;
                 }
             }
+        }
+
+        if (OK && ch_len == 4)
+        {
+            // Unicode limit 0x10FFFF
+            unsigned char c0 = text[i];
+            unsigned char c1 = text[i + 1];
+            OK = ((c0 & 0b0000'0111) << 6 | (c1 & 0b00111111)) <= 0x10f;
         }
 
         if (OK)

--- a/parser_library/src/workspaces/file_impl.h
+++ b/parser_library/src/workspaces/file_impl.h
@@ -49,7 +49,7 @@ public:
     void did_change(range range, std::string new_text) override;
     void did_close() override;
 
-    static std::string replace_non_utf8_chars(const std::string& text);
+    static std::string replace_non_utf8_chars(std::string_view text);
     static std::vector<size_t> create_line_indices(const std::string& text);
 
     // Returns the location in text that corresponds to utf-16 based location

--- a/parser_library/test/diagnosable_ctx_test.cpp
+++ b/parser_library/test/diagnosable_ctx_test.cpp
@@ -43,8 +43,8 @@ TEST(diagnosable_ctx, one_file_diag)
     a.collect_diags();
     ASSERT_EQ(a.diags().size(), (size_t)1);
 
-    EXPECT_EQ(a.diags()[0].diag_range.start.line, (position_t)2);
+    EXPECT_EQ(a.diags()[0].diag_range.start.line, (size_t)2);
     EXPECT_EQ(a.diags()[0].related.size(), (size_t)2);
-    EXPECT_EQ(a.diags()[0].related[0].location.rang.start.line, (position_t)8);
-    EXPECT_EQ(a.diags()[0].related[1].location.rang.start.line, (position_t)13);
+    EXPECT_EQ(a.diags()[0].related[0].location.rang.start.line, (size_t)8);
+    EXPECT_EQ(a.diags()[0].related[1].location.rang.start.line, (size_t)13);
 }

--- a/parser_library/test/processing/aread_test.cpp
+++ b/parser_library/test/processing/aread_test.cpp
@@ -569,3 +569,37 @@ removed by aread
     EXPECT_FALSE(a1.has_value());
     EXPECT_EQ(a2, 2);
 }
+
+TEST(aread, last_statements_in_copy)
+{
+    std::string input = R"(
+          COPY  COPYCOPY
+&A1       SETA  1                                                      X this line is removed by the macro
+&A2       SETA  2
+)";
+    asm_options_invalid_lib_provider lib_provider {
+        { "MAC", R"(*
+          MACRO
+          MAC
+&VAR      AREAD
+          MEND
+)" },
+        { "COPYCOPY", R"( COPY COPYBOOK)" },
+        { "COPYBOOK", R"( MAC)" },
+    };
+
+    analyzer a(input, analyzer_options { &lib_provider });
+    a.analyze();
+
+    a.collect_diags();
+    auto& diags = a.diags();
+    ASSERT_EQ(diags.size(), 0);
+
+    auto& ctx = a.hlasm_ctx();
+
+    auto a1 = get_var_value<A_t>(ctx, "A1");
+    auto a2 = get_var_value<A_t>(ctx, "A2");
+
+    EXPECT_FALSE(a1.has_value());
+    EXPECT_EQ(a2, 2);
+}

--- a/parser_library/test/processing/aread_test.cpp
+++ b/parser_library/test/processing/aread_test.cpp
@@ -648,7 +648,7 @@ TEST(aread, copy_in_macro)
         { "MAC", R"(*
           MACRO
           MAC
-          AINSERT '&A1       SETA  1    removed by the macro',FRONT
+          AINSERT '&&A1       SETA  1    removed by the macro',FRONT
           COPY MACINNER
           MEND
 )" },

--- a/parser_library/test/processing/aread_test.cpp
+++ b/parser_library/test/processing/aread_test.cpp
@@ -640,3 +640,37 @@ removed on first call                                                  X
     EXPECT_FALSE(a1.has_value());
     EXPECT_EQ(a2, 2);
 }
+
+TEST(aread, copy_in_macro)
+{
+    std::string input = R"( COPY  COPYBOOK)";
+    asm_options_invalid_lib_provider lib_provider {
+        { "MAC", R"(*
+          MACRO
+          MAC
+          AINSERT '&A1       SETA  1    removed by the macro',FRONT
+          COPY MACINNER
+          MEND
+)" },
+        { "MACINNER", "&VAR      AREAD" },
+        { "COPYBOOK", R"(
+          MAC
+&A2       SETA  2
+)" },
+    };
+
+    analyzer a(input, analyzer_options { &lib_provider });
+    a.analyze();
+
+    a.collect_diags();
+    auto& diags = a.diags();
+    ASSERT_EQ(diags.size(), 0);
+
+    auto& ctx = a.hlasm_ctx();
+
+    auto a1 = get_var_value<A_t>(ctx, "A1");
+    auto a2 = get_var_value<A_t>(ctx, "A2");
+
+    EXPECT_FALSE(a1.has_value());
+    EXPECT_EQ(a2, 2);
+}

--- a/parser_library/test/processing/copy_test.cpp
+++ b/parser_library/test/processing/copy_test.cpp
@@ -76,10 +76,10 @@ TEST(copy, copy_enter_diag_test)
 
     auto diag = a.diags()[0];
 
-    EXPECT_EQ(a.diags()[0].diag_range.start.line, (position_t)2);
+    EXPECT_EQ(a.diags()[0].diag_range.start.line, (size_t)2);
     EXPECT_EQ(a.diags()[0].file_name, "COPYD");
     EXPECT_EQ(a.diags()[0].related.size(), (size_t)1);
-    EXPECT_EQ(a.diags()[0].related[0].location.rang.start.line, (position_t)1);
+    EXPECT_EQ(a.diags()[0].related[0].location.rang.start.line, (size_t)1);
     EXPECT_EQ(a.diags()[0].related[0].location.uri, "start");
 }
 
@@ -208,10 +208,10 @@ TEST(copy, copy_enter_from_macro_call)
 
     ASSERT_EQ(a.diags().size(), (size_t)1);
 
-    EXPECT_EQ(a.diags()[0].diag_range.start.line, (position_t)16);
+    EXPECT_EQ(a.diags()[0].diag_range.start.line, (size_t)16);
     EXPECT_EQ(a.diags()[0].file_name, "COPYR");
     ASSERT_EQ(a.diags()[0].related.size(), (size_t)1);
-    EXPECT_EQ(a.diags()[0].related[0].location.rang.start.line, (position_t)5);
+    EXPECT_EQ(a.diags()[0].related[0].location.rang.start.line, (size_t)5);
     EXPECT_EQ(a.diags()[0].related[0].location.uri, "start");
 }
 
@@ -243,10 +243,10 @@ TEST(copy, copy_enter_from_lookahead)
 
     ASSERT_EQ(a.diags().size(), (size_t)1);
 
-    EXPECT_EQ(a.diags()[0].diag_range.start.line, (position_t)6);
+    EXPECT_EQ(a.diags()[0].diag_range.start.line, (size_t)6);
     EXPECT_EQ(a.diags()[0].file_name, "COPYL");
     ASSERT_EQ(a.diags()[0].related.size(), (size_t)1);
-    EXPECT_EQ(a.diags()[0].related[0].location.rang.start.line, (position_t)4);
+    EXPECT_EQ(a.diags()[0].related[0].location.rang.start.line, (size_t)4);
     EXPECT_EQ(a.diags()[0].related[0].location.uri, "start");
 }
 
@@ -301,10 +301,10 @@ TEST(copy, macro_from_copy_call)
 
     ASSERT_EQ(a.diags().size(), (size_t)1);
 
-    EXPECT_EQ(a.diags()[0].diag_range.start.line, (position_t)3);
+    EXPECT_EQ(a.diags()[0].diag_range.start.line, (size_t)3);
     EXPECT_EQ(a.diags()[0].file_name, "COPYBM");
     ASSERT_EQ(a.diags()[0].related.size(), (size_t)1);
-    EXPECT_EQ(a.diags()[0].related[0].location.rang.start.line, (position_t)2);
+    EXPECT_EQ(a.diags()[0].related[0].location.rang.start.line, (size_t)2);
     EXPECT_EQ(a.diags()[0].related[0].location.uri, "start");
 }
 
@@ -345,16 +345,16 @@ TEST(copy, jump_from_copy_fail)
     EXPECT_EQ(a.diags().size(), (size_t)2);
     EXPECT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
 
-    EXPECT_EQ(a.diags()[1].diag_range.start.line, (position_t)2);
+    EXPECT_EQ(a.diags()[1].diag_range.start.line, (size_t)2);
     EXPECT_EQ(a.diags()[1].file_name, "COPYJF");
     ASSERT_EQ(a.diags()[1].related.size(), (size_t)1);
-    EXPECT_EQ(a.diags()[1].related[0].location.rang.start.line, (position_t)1);
+    EXPECT_EQ(a.diags()[1].related[0].location.rang.start.line, (size_t)1);
     EXPECT_EQ(a.diags()[1].related[0].location.uri, "start");
 
-    EXPECT_EQ(a.diags()[0].diag_range.start.line, (position_t)1);
+    EXPECT_EQ(a.diags()[0].diag_range.start.line, (size_t)1);
     EXPECT_EQ(a.diags()[0].file_name, "COPYJF");
     ASSERT_EQ(a.diags()[0].related.size(), (size_t)1);
-    EXPECT_EQ(a.diags()[0].related[0].location.rang.start.line, (position_t)1);
+    EXPECT_EQ(a.diags()[0].related[0].location.rang.start.line, (size_t)1);
     EXPECT_EQ(a.diags()[0].related[0].location.uri, "start");
 }
 
@@ -380,12 +380,12 @@ TEST(copy, jump_in_macro_from_copy_fail)
     EXPECT_EQ(a.diags().size(), (size_t)2);
     EXPECT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
 
-    EXPECT_EQ(a.diags()[0].diag_range.start.line, (position_t)1);
+    EXPECT_EQ(a.diags()[0].diag_range.start.line, (size_t)1);
     EXPECT_EQ(a.diags()[0].file_name, "COPYJF");
     ASSERT_EQ(a.diags()[0].related.size(), (size_t)2);
-    EXPECT_EQ(a.diags()[0].related[0].location.rang.start.line, (position_t)3);
+    EXPECT_EQ(a.diags()[0].related[0].location.rang.start.line, (size_t)3);
     EXPECT_EQ(a.diags()[0].related[0].location.uri, "start");
-    EXPECT_EQ(a.diags()[0].related[1].location.rang.start.line, (position_t)6);
+    EXPECT_EQ(a.diags()[0].related[1].location.rang.start.line, (size_t)6);
     EXPECT_EQ(a.diags()[0].related[1].location.uri, "start");
 }
 
@@ -412,14 +412,14 @@ TEST(copy, macro_nested_diagnostics)
     EXPECT_EQ(a.diags().size(), (size_t)1);
     EXPECT_EQ(a.parser().getNumberOfSyntaxErrors(), (size_t)0);
 
-    EXPECT_EQ(a.diags()[0].diag_range.start.line, (position_t)4);
+    EXPECT_EQ(a.diags()[0].diag_range.start.line, (size_t)4);
     EXPECT_EQ(a.diags()[0].file_name, "COPYND2");
     ASSERT_EQ(a.diags()[0].related.size(), (size_t)3);
-    EXPECT_EQ(a.diags()[0].related[0].location.rang.start.line, (position_t)1);
+    EXPECT_EQ(a.diags()[0].related[0].location.rang.start.line, (size_t)1);
     EXPECT_EQ(a.diags()[0].related[0].location.uri, "COPYND1");
-    EXPECT_EQ(a.diags()[0].related[1].location.rang.start.line, (position_t)3);
+    EXPECT_EQ(a.diags()[0].related[1].location.rang.start.line, (size_t)3);
     EXPECT_EQ(a.diags()[0].related[1].location.uri, "start");
-    EXPECT_EQ(a.diags()[0].related[2].location.rang.start.line, (position_t)7);
+    EXPECT_EQ(a.diags()[0].related[2].location.rang.start.line, (size_t)7);
     EXPECT_EQ(a.diags()[0].related[2].location.uri, "start");
 }
 

--- a/parser_library/test/stability_test.cpp
+++ b/parser_library/test/stability_test.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2019 Broadcom.
  * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
  *
@@ -100,3 +100,63 @@ TEST(stability_test, entry_7)
     analyzer a(input);
     a.analyze();
 }
+
+#if 0
+TEST(stability_test, entry_8)
+{
+    std::string input(R"(T&STSSSS(&())))())");
+
+    analyzer a(input);
+    a.analyze();
+    a.collect_diags();
+}
+
+TEST(stability_test, entry_9)
+{
+    std::string input(" T&STSS(&(&STSS(&())S))S))S))))()-&"
+                      "\xEF\xBF\xBD\xEF\xBF\xBD"
+                      "?"
+                      "\xEF\xBF\xBD\xEF\xBF\xBD");
+
+    analyzer a(input);
+    a.analyze();
+    a.collect_diags();
+}
+
+TEST(stability_test, entry_10)
+{
+    std::string input(R"(T&ST&WT&ST&W((SS((SS))))())");
+
+    analyzer a(input);
+    a.analyze();
+    a.collect_diags();
+}
+
+TEST(stability_test, entry_11)
+{
+    std::string input(R"( D
+
+D DS  z)"
+                      "\xC2\x96"
+                      R"(M0@(L0)&GDDS NG+n&n((&D D
+,$N&D ')"
+                      "\x0\x10"
+                      "'''-D&SCB "
+                      "\xC2\xAC");
+
+    analyzer a(input);
+    a.analyze();
+    a.collect_diags();
+}
+
+TEST(stability_test, entry_12)
+{
+    std::string input(R"(q DS  z)"
+                      "\xC2\x96"
+                      R"(M0@(L0)&GDDS NG+)");
+
+    analyzer a(input);
+    a.analyze();
+    a.collect_diags();
+}
+#endif


### PR DESCRIPTION
fix: Address edge cases when AREAD and AINSERT are called from source code brought by COPY instruction.
feat: Add support for macro library to fuzzer.