### PR TITLE
fix: Inline macros overwriting external definition stored in macro cache

### DIFF
--- a/parser_library/include/protocol.h
+++ b/parser_library/include/protocol.h
@@ -223,13 +223,14 @@ struct PARSER_LIBRARY_EXPORT performance_metrics
     size_t files = 0;
 };
 
-bool inline operator==(const performance_metrics& lhs, const performance_metrics& oth)
+bool inline operator==(const performance_metrics& lhs, const performance_metrics& rhs)
 {
-    return lhs.lines == oth.lines && lhs.macro_def_statements == oth.macro_def_statements
-        && lhs.open_code_statements == oth.open_code_statements && lhs.copy_def_statements == oth.copy_def_statements
-        && lhs.copy_statements == oth.copy_statements && lhs.reparsed_statements == oth.reparsed_statements
-        && lhs.lookahead_statements == oth.lookahead_statements && lhs.continued_statements == oth.continued_statements
-        && lhs.non_continued_statements == oth.non_continued_statements && lhs.files == oth.files;
+    return lhs.lines == rhs.lines && lhs.macro_def_statements == rhs.macro_def_statements
+        && lhs.macro_statements == rhs.macro_statements && lhs.open_code_statements == rhs.open_code_statements
+        && lhs.copy_def_statements == rhs.copy_def_statements && lhs.copy_statements == rhs.copy_statements
+        && lhs.reparsed_statements == rhs.reparsed_statements && lhs.lookahead_statements == rhs.lookahead_statements
+        && lhs.continued_statements == rhs.continued_statements
+        && lhs.non_continued_statements == rhs.non_continued_statements && lhs.files == rhs.files;
 }
 
 struct PARSER_LIBRARY_EXPORT diagnostic_list

--- a/parser_library/include/protocol.h
+++ b/parser_library/include/protocol.h
@@ -221,8 +221,6 @@ struct PARSER_LIBRARY_EXPORT performance_metrics
     size_t continued_statements = 0;
     size_t non_continued_statements = 0;
     size_t files = 0;
-
-    
 };
 
 bool inline operator==(const performance_metrics& lhs, const performance_metrics& oth)

--- a/parser_library/include/protocol.h
+++ b/parser_library/include/protocol.h
@@ -221,7 +221,18 @@ struct PARSER_LIBRARY_EXPORT performance_metrics
     size_t continued_statements = 0;
     size_t non_continued_statements = 0;
     size_t files = 0;
+
+    
 };
+
+bool inline operator==(const performance_metrics& lhs, const performance_metrics& oth)
+{
+    return lhs.lines == oth.lines && lhs.macro_def_statements == oth.macro_def_statements
+        && lhs.open_code_statements == oth.open_code_statements && lhs.copy_def_statements == oth.copy_def_statements
+        && lhs.copy_statements == oth.copy_statements && lhs.reparsed_statements == oth.reparsed_statements
+        && lhs.lookahead_statements == oth.lookahead_statements && lhs.continued_statements == oth.continued_statements
+        && lhs.non_continued_statements == oth.non_continued_statements && lhs.files == oth.files;
+}
 
 struct PARSER_LIBRARY_EXPORT diagnostic_list
 {

--- a/parser_library/src/analyzer.cpp
+++ b/parser_library/src/analyzer.cpp
@@ -27,11 +27,12 @@ analyzing_context& analyzer_options::get_context()
 {
     if (std::holds_alternative<asm_option>(ctx_source))
     {
+        auto h_ctx = std::make_shared<context::hlasm_context>(file_name,
+            std::move(std::get<asm_option>(ctx_source)),
+            ids_init.has_value() ? std::move(*ids_init) : id_storage {});
         ctx_source = analyzing_context {
-            std::make_unique<context::hlasm_context>(file_name,
-                std::move(std::get<asm_option>(ctx_source)),
-                ids_init.has_value() ? std::move(*ids_init) : id_storage {}),
-            std::make_unique<lsp::lsp_context>(),
+            h_ctx,
+            std::make_unique<lsp::lsp_context>(h_ctx),
         };
     }
     return std::get<analyzing_context>(ctx_source);

--- a/parser_library/src/expressions/evaluation_context.h
+++ b/parser_library/src/expressions/evaluation_context.h
@@ -27,7 +27,7 @@ struct evaluation_context : public diagnosable_ctx
     workspaces::parse_lib_provider& lib_provider;
 
     evaluation_context(context::hlasm_context& ctx, workspaces::parse_lib_provider& lib_provider)
-        : diagnosable_ctx(hlasm_ctx)
+        : diagnosable_ctx(ctx)
         , hlasm_ctx(ctx)
         , lib_provider(lib_provider)
     {}

--- a/parser_library/src/expressions/evaluation_context.h
+++ b/parser_library/src/expressions/evaluation_context.h
@@ -23,14 +23,12 @@ namespace hlasm_plugin::parser_library::expressions {
 // structure holding required objects to correcly perform evaluation of expressions
 struct evaluation_context : public diagnosable_ctx
 {
-    analyzing_context ctx;
     context::hlasm_context& hlasm_ctx;
     workspaces::parse_lib_provider& lib_provider;
 
-    evaluation_context(analyzing_context ctx, workspaces::parse_lib_provider& lib_provider)
-        : diagnosable_ctx(*ctx.hlasm_ctx)
-        , ctx(ctx)
-        , hlasm_ctx(*ctx.hlasm_ctx)
+    evaluation_context(context::hlasm_context& ctx, workspaces::parse_lib_provider& lib_provider)
+        : diagnosable_ctx(hlasm_ctx)
+        , hlasm_ctx(ctx)
         , lib_provider(lib_provider)
     {}
 

--- a/parser_library/src/lsp/lsp_context.h
+++ b/parser_library/src/lsp/lsp_context.h
@@ -32,7 +32,7 @@ class lsp_context final : public feature_provider
     std::shared_ptr<context::hlasm_context> hlasm_ctx_;
 
 public:
-    lsp_context(std::shared_ptr<context::hlasm_context> h_ctx);
+    explicit lsp_context(std::shared_ptr<context::hlasm_context> h_ctx);
 
     void add_copy(context::copy_member_ptr copy, text_data_ref_t text_data);
     void add_macro(macro_info_ptr macro_i, text_data_ref_t text_data = text_data_ref_t());

--- a/parser_library/src/lsp/lsp_context.h
+++ b/parser_library/src/lsp/lsp_context.h
@@ -29,7 +29,11 @@ class lsp_context final : public feature_provider
     std::unordered_map<std::string, file_info_ptr> files_;
     std::unordered_map<context::macro_def_ptr, macro_info_ptr> macros_;
 
+    std::shared_ptr<context::hlasm_context> hlasm_ctx_;
+
 public:
+    lsp_context(std::shared_ptr<context::hlasm_context> h_ctx);
+
     void add_copy(context::copy_member_ptr copy, text_data_ref_t text_data);
     void add_macro(macro_info_ptr macro_i, text_data_ref_t text_data = text_data_ref_t());
     void add_opencode(opencode_info_ptr opencode_i, text_data_ref_t text_data);

--- a/parser_library/src/lsp/opencode_info.h
+++ b/parser_library/src/lsp/opencode_info.h
@@ -26,14 +26,11 @@ using opencode_info_ptr = std::unique_ptr<opencode_info>;
 
 struct opencode_info
 {
-    context::hlasm_context& hlasm_ctx;
     vardef_storage variable_definitions;
     file_occurences_t file_occurences;
 
-    opencode_info(
-        context::hlasm_context& hlasm_ctx, vardef_storage variable_definitions, file_occurences_t file_occurences)
-        : hlasm_ctx(hlasm_ctx)
-        , variable_definitions(std::move(variable_definitions))
+    opencode_info(vardef_storage variable_definitions, file_occurences_t file_occurences)
+        : variable_definitions(std::move(variable_definitions))
         , file_occurences(std::move(file_occurences))
     {}
 };

--- a/parser_library/src/processing/instruction_sets/instruction_processor.h
+++ b/parser_library/src/processing/instruction_sets/instruction_processor.h
@@ -49,7 +49,7 @@ protected:
         , hlasm_ctx(*ctx.hlasm_ctx)
         , branch_provider(branch_provider)
         , lib_provider(lib_provider)
-        , eval_ctx { ctx, lib_provider }
+        , eval_ctx { *ctx.hlasm_ctx, lib_provider }
     {}
 };
 

--- a/parser_library/src/processing/opencode_provider.cpp
+++ b/parser_library/src/processing/opencode_provider.cpp
@@ -239,7 +239,7 @@ std::shared_ptr<const context::hlasm_statement> opencode_provider::process_ordin
 {
     if (proc.kind == processing::processing_kind::ORDINARY
         && try_trigger_attribute_lookahead(
-            collector.current_instruction(), { *m_ctx, *m_lib_provider }, *m_state_listener))
+            collector.current_instruction(), { *m_ctx->hlasm_ctx, *m_lib_provider }, *m_state_listener))
         return nullptr;
 
     m_ctx->hlasm_ctx->set_source_position(collector.current_instruction().field_range.start);
@@ -312,7 +312,7 @@ std::shared_ptr<const context::hlasm_statement> opencode_provider::process_ordin
     auto result = collector.extract_statement(proc_status, statement_range);
 
     if (proc.kind == processing::processing_kind::ORDINARY
-        && try_trigger_attribute_lookahead(*result, { *m_ctx, *m_lib_provider }, *m_state_listener))
+        && try_trigger_attribute_lookahead(*result, { *m_ctx->hlasm_ctx, *m_lib_provider }, *m_state_listener))
         return nullptr;
 
     if (m_current_logical_line.segments.size() > 1)

--- a/parser_library/src/processing/statement_analyzers/lsp_analyzer.cpp
+++ b/parser_library/src/processing/statement_analyzers/lsp_analyzer.cpp
@@ -113,8 +113,8 @@ void lsp_analyzer::copydef_finished(context::copy_member_ptr copydef, copy_proce
 
 void lsp_analyzer::opencode_finished()
 {
-    lsp_ctx_.add_opencode(std::make_unique<lsp::opencode_info>(
-                              hlasm_ctx_, std::move(opencode_var_defs_), std::move(opencode_occurences_)),
+    lsp_ctx_.add_opencode(
+        std::make_unique<lsp::opencode_info>(std::move(opencode_var_defs_), std::move(opencode_occurences_)),
         lsp::text_data_ref_t(file_text_));
 }
 

--- a/parser_library/src/processing/statement_processors/ordinary_processor.cpp
+++ b/parser_library/src/processing/statement_processors/ordinary_processor.cpp
@@ -29,7 +29,7 @@ ordinary_processor::ordinary_processor(analyzing_context ctx,
     statement_fields_parser& parser,
     opencode_provider& open_code)
     : statement_processor(processing_kind::ORDINARY, ctx)
-    , eval_ctx { ctx, lib_provider }
+    , eval_ctx { *ctx.hlasm_ctx, lib_provider }
     , ca_proc_(ctx, branch_provider, lib_provider, state_listener, open_code)
     , mac_proc_(ctx, branch_provider, lib_provider)
     , asm_proc_(ctx, branch_provider, lib_provider, parser, open_code)

--- a/parser_library/src/processing/statement_providers/members_statement_provider.cpp
+++ b/parser_library/src/processing/statement_providers/members_statement_provider.cpp
@@ -41,7 +41,7 @@ context::shared_stmt_ptr members_statement_provider::get_next(const statement_pr
         return nullptr;
 
     if (processor.kind == processing_kind::ORDINARY
-        && try_trigger_attribute_lookahead(retrieve_instruction(*cache), { ctx, lib_provider }, listener))
+        && try_trigger_attribute_lookahead(retrieve_instruction(*cache), { *ctx.hlasm_ctx, lib_provider }, listener))
         return nullptr;
 
     context::shared_stmt_ptr stmt;
@@ -61,7 +61,7 @@ context::shared_stmt_ptr members_statement_provider::get_next(const statement_pr
 
 
     if (processor.kind == processing_kind::ORDINARY
-        && try_trigger_attribute_lookahead(*stmt, { ctx, lib_provider }, listener))
+        && try_trigger_attribute_lookahead(*stmt, { *ctx.hlasm_ctx, lib_provider }, listener))
         return nullptr;
 
     return stmt;

--- a/parser_library/src/workspaces/macro_cache.h
+++ b/parser_library/src/workspaces/macro_cache.h
@@ -72,7 +72,7 @@ struct macro_cache_data
     // Versions of respective macro (copy member) with all dependencies (COPY instruction is evaluated during macro
     // definition and the statements are part of macro definition)
     version_stamp stamps;
-    std::unique_ptr<analyzer> cached_analyzer;
+    std::variant<lsp::macro_info_ptr, context::copy_member_ptr> cached_member;
 };
 
 class macro_cache final : public diagnosable_impl
@@ -90,7 +90,7 @@ public:
     void erase_cache_of_opencode(const std::string& opencode_file_name);
 
 private:
-    [[nodiscard]] const analyzer* find_cached_analyzer(const macro_cache_key& key) const;
+    [[nodiscard]] const macro_cache_data* find_cached_data(const macro_cache_key& key) const;
     [[nodiscard]] version_stamp get_copy_member_versions(context::macro_def_ptr ctx) const;
 
     void collect_diags() const override;

--- a/parser_library/src/workspaces/processor_file_impl.cpp
+++ b/parser_library/src/workspaces/processor_file_impl.cpp
@@ -151,19 +151,19 @@ namespace {
 class empty_feature_provider final : public lsp::feature_provider
 {
     // Inherited via feature_provider
-    virtual location definition(const std::string& document_uri, position pos) const override
+    location definition(const std::string& document_uri, position pos) const override
     {
         return location(pos, document_uri);
     }
-    virtual location_list references(const std::string& document_uri, position pos) const override
+    location_list references(const std::string& document_uri, position pos) const override
     {
         return location_list();
     }
-    virtual lsp::hover_result hover(const std::string& document_uri, position pos) const override
+    lsp::hover_result hover(const std::string& document_uri, position pos) const override
     {
         return lsp::hover_result();
     }
-    virtual lsp::completion_list_s completion(const std::string& document_uri,
+    lsp::completion_list_s completion(const std::string& document_uri,
         position pos,
         char trigger_char,
         completion_trigger_kind trigger_kind) const override

--- a/parser_library/src/workspaces/processor_file_impl.cpp
+++ b/parser_library/src/workspaces/processor_file_impl.cpp
@@ -155,10 +155,7 @@ class empty_feature_provider final : public lsp::feature_provider
     {
         return location(pos, document_uri);
     }
-    location_list references(const std::string& document_uri, position pos) const override
-    {
-        return location_list();
-    }
+    location_list references(const std::string& document_uri, position pos) const override { return location_list(); }
     lsp::hover_result hover(const std::string& document_uri, position pos) const override
     {
         return lsp::hover_result();

--- a/parser_library/src/workspaces/processor_file_impl.cpp
+++ b/parser_library/src/workspaces/processor_file_impl.cpp
@@ -151,7 +151,10 @@ namespace {
 class empty_feature_provider final : public lsp::feature_provider
 {
     // Inherited via feature_provider
-    virtual location definition(const std::string& document_uri, position pos) const override { return location(); }
+    virtual location definition(const std::string& document_uri, position pos) const override
+    {
+        return location(pos, document_uri);
+    }
     virtual location_list references(const std::string& document_uri, position pos) const override
     {
         return location_list();
@@ -174,14 +177,20 @@ const lsp::feature_provider& processor_file_impl::get_lsp_feature_provider()
 {
     if (last_analyzer_)
         return *last_analyzer_->context().lsp_ctx;
-    
+
     const static empty_feature_provider empty_res;
     return empty_res;
 }
 
 const std::set<std::string>& processor_file_impl::files_to_close() { return files_to_close_; }
 
-const performance_metrics& processor_file_impl::get_metrics() { return last_analyzer_->get_metrics(); }
+const performance_metrics& processor_file_impl::get_metrics()
+{
+    if (last_analyzer_)
+        return last_analyzer_->get_metrics();
+    const static performance_metrics metrics;
+    return metrics;
+}
 
 void processor_file_impl::erase_cache_of_opencode(const std::string& opencode_file_name)
 {

--- a/parser_library/src/workspaces/processor_file_impl.cpp
+++ b/parser_library/src/workspaces/processor_file_impl.cpp
@@ -140,12 +140,43 @@ const std::set<std::string>& processor_file_impl::dependencies() { return depend
 
 const semantics::lines_info& processor_file_impl::get_hl_info()
 {
-    return last_analyzer_->source_processor().semantic_tokens();
+    if (last_analyzer_)
+        return last_analyzer_->source_processor().semantic_tokens();
+
+    const static semantics::lines_info empty_lines;
+    return empty_lines;
 }
+
+namespace {
+class empty_feature_provider final : public lsp::feature_provider
+{
+    // Inherited via feature_provider
+    virtual location definition(const std::string& document_uri, position pos) const override { return location(); }
+    virtual location_list references(const std::string& document_uri, position pos) const override
+    {
+        return location_list();
+    }
+    virtual lsp::hover_result hover(const std::string& document_uri, position pos) const override
+    {
+        return lsp::hover_result();
+    }
+    virtual lsp::completion_list_s completion(const std::string& document_uri,
+        position pos,
+        char trigger_char,
+        completion_trigger_kind trigger_kind) const override
+    {
+        return {};
+    }
+};
+} // namespace
 
 const lsp::feature_provider& processor_file_impl::get_lsp_feature_provider()
 {
-    return *last_analyzer_->context().lsp_ctx;
+    if (last_analyzer_)
+        return *last_analyzer_->context().lsp_ctx;
+    
+    const static empty_feature_provider empty_res;
+    return empty_res;
 }
 
 const std::set<std::string>& processor_file_impl::files_to_close() { return files_to_close_; }

--- a/parser_library/src/workspaces/processor_file_impl.h
+++ b/parser_library/src/workspaces/processor_file_impl.h
@@ -54,7 +54,7 @@ public:
 
 private:
     std::unique_ptr<analyzer> opencode_analyzer_;
-    const analyzer* last_analyzer_;
+    const analyzer* last_analyzer_ = nullptr;
 
     bool parse_inner(analyzer&);
 

--- a/parser_library/test/expressions/ca_constant_test.cpp
+++ b/parser_library/test/expressions/ca_constant_test.cpp
@@ -24,8 +24,7 @@ using namespace hlasm_plugin::parser_library;
 TEST(ca_constant, undefined_attributes)
 {
     context::hlasm_context ctx;
-    evaluation_context eval_ctx { ctx,
-        workspaces::empty_parse_lib_provider::instance };
+    evaluation_context eval_ctx { ctx, workspaces::empty_parse_lib_provider::instance };
 
     ca_constant c(1, range());
 

--- a/parser_library/test/expressions/ca_constant_test.cpp
+++ b/parser_library/test/expressions/ca_constant_test.cpp
@@ -23,8 +23,8 @@ using namespace hlasm_plugin::parser_library;
 
 TEST(ca_constant, undefined_attributes)
 {
-    evaluation_context eval_ctx { analyzing_context { std::make_shared<context::hlasm_context>(),
-                                      std::make_shared<lsp::lsp_context>() },
+    context::hlasm_context ctx;
+    evaluation_context eval_ctx { ctx,
         workspaces::empty_parse_lib_provider::instance };
 
     ca_constant c(1, range());

--- a/parser_library/test/expressions/ca_expr_list_test.cpp
+++ b/parser_library/test/expressions/ca_expr_list_test.cpp
@@ -29,9 +29,8 @@ using namespace hlasm_plugin::parser_library;
 
 TEST(ca_expr_list, unknown_function_to_operator)
 {
-    evaluation_context eval_ctx { analyzing_context { std::make_shared<context::hlasm_context>(),
-                                      std::make_shared<lsp::lsp_context>() },
-        workspaces::empty_parse_lib_provider::instance };
+    context::hlasm_context ctx;
+    evaluation_context eval_ctx { ctx, workspaces::empty_parse_lib_provider::instance };
 
     std::string name = "AND";
     auto c = std::make_unique<ca_constant>(1, range());
@@ -57,9 +56,8 @@ TEST(ca_expr_list, unknown_function_to_operator)
 
 TEST(ca_expr_list, resolve_C_type)
 {
-    evaluation_context eval_ctx { analyzing_context { std::make_shared<context::hlasm_context>(),
-                                      std::make_shared<lsp::lsp_context>() },
-        workspaces::empty_parse_lib_provider::instance };
+    context::hlasm_context ctx;
+    evaluation_context eval_ctx { ctx, workspaces::empty_parse_lib_provider::instance };
 
     std::string name = "UPPER";
     auto sym = std::make_unique<ca_symbol>(&name, range());
@@ -96,9 +94,8 @@ TEST(ca_expr_list, get_undefined_attributed_symbols)
     // (L'X 'low')
     ca_expr_list expr_list(std::move(list), range());
 
-    evaluation_context eval_ctx { analyzing_context { std::make_shared<context::hlasm_context>(),
-                                      std::make_shared<lsp::lsp_context>() },
-        workspaces::empty_parse_lib_provider::instance };
+    context::hlasm_context ctx;
+    evaluation_context eval_ctx { ctx, workspaces::empty_parse_lib_provider::instance };
     auto res = expr_list.get_undefined_attributed_symbols(eval_ctx);
 
     ASSERT_TRUE(res.size());

--- a/parser_library/test/expressions/ca_function_test.cpp
+++ b/parser_library/test/expressions/ca_function_test.cpp
@@ -77,9 +77,8 @@ public:
 class ca_func : public ::testing::TestWithParam<func_test_param>
 {
 protected:
-    evaluation_context eval_ctx { analyzing_context { std::make_shared<context::hlasm_context>(),
-                                      std::make_shared<lsp::lsp_context>() },
-        workspaces::empty_parse_lib_provider::instance };
+    context::hlasm_context ctx;
+    evaluation_context eval_ctx { ctx, workspaces::empty_parse_lib_provider::instance };
 
     context::SET_t get_result()
     {

--- a/parser_library/test/expressions/ca_operator_test.cpp
+++ b/parser_library/test/expressions/ca_operator_test.cpp
@@ -57,9 +57,8 @@ struct stringer
 class ca_op : public ::testing::TestWithParam<op_test_param>
 {
 protected:
-    evaluation_context eval_ctx { analyzing_context { std::make_shared<context::hlasm_context>(),
-                                      std::make_shared<lsp::lsp_context>() },
-        workspaces::empty_parse_lib_provider::instance };
+    context::hlasm_context ctx;
+    evaluation_context eval_ctx { ctx, workspaces::empty_parse_lib_provider::instance };
 
     SET_t get_result()
     {

--- a/parser_library/test/expressions/ca_string_test.cpp
+++ b/parser_library/test/expressions/ca_string_test.cpp
@@ -26,9 +26,8 @@ using namespace hlasm_plugin::parser_library;
 
 TEST(ca_string, undefined_attributes)
 {
-    auto hlasm_ctx = std::make_shared<context::hlasm_context>();
-    evaluation_context eval_ctx { analyzing_context { hlasm_ctx, std::make_shared<lsp::lsp_context>() },
-        workspaces::empty_parse_lib_provider::instance };
+    context::hlasm_context ctx;
+    evaluation_context eval_ctx { ctx, workspaces::empty_parse_lib_provider::instance };
 
     concat_chain value;
     value.push_back(std::make_unique<char_str_conc>("gfds", range()));
@@ -81,9 +80,8 @@ TEST(ca_string, test)
 
     ca_string s(std::move(value), std::move(dupl), ca_string::substring_t(), range());
 
-    evaluation_context eval_ctx { analyzing_context { std::make_shared<context::hlasm_context>(),
-                                      std::make_shared<lsp::lsp_context>() },
-        workspaces::empty_parse_lib_provider::instance };
+    context::hlasm_context ctx;
+    evaluation_context eval_ctx { ctx, workspaces::empty_parse_lib_provider::instance };
 
     auto res = s.evaluate(eval_ctx);
 
@@ -101,9 +99,8 @@ TEST_P(ca_string_suite, dupl)
 
     ca_string s(std::move(value), std::move(dupl), ca_string::substring_t(), range());
 
-    evaluation_context eval_ctx { analyzing_context { std::make_shared<context::hlasm_context>(),
-                                      std::make_shared<lsp::lsp_context>() },
-        workspaces::empty_parse_lib_provider::instance };
+    context::hlasm_context ctx;
+    evaluation_context eval_ctx { ctx, workspaces::empty_parse_lib_provider::instance };
 
     auto res = s.evaluate(eval_ctx);
 

--- a/parser_library/test/expressions/ca_symbol_attribute_test.cpp
+++ b/parser_library/test/expressions/ca_symbol_attribute_test.cpp
@@ -115,8 +115,7 @@ class ca_attr : public ::testing::TestWithParam<attr_test_param>
 {
 protected:
     std::shared_ptr<context::hlasm_context> hlasm_ctx = std::make_shared<context::hlasm_context>();
-    evaluation_context eval_ctx { *hlasm_ctx,
-        workspaces::empty_parse_lib_provider::instance };
+    evaluation_context eval_ctx { *hlasm_ctx, workspaces::empty_parse_lib_provider::instance };
 };
 
 INSTANTIATE_TEST_SUITE_P(ca_attr_suite,

--- a/parser_library/test/expressions/ca_symbol_attribute_test.cpp
+++ b/parser_library/test/expressions/ca_symbol_attribute_test.cpp
@@ -25,9 +25,8 @@ using namespace hlasm_plugin::parser_library;
 
 TEST(ca_symbol_attr, undefined_attributes)
 {
-    auto hlasm_ctx = std::make_shared<context::hlasm_context>();
-    evaluation_context eval_ctx { analyzing_context { hlasm_ctx, std::make_shared<lsp::lsp_context>() },
-        workspaces::empty_parse_lib_provider::instance };
+    context::hlasm_context ctx;
+    evaluation_context eval_ctx { ctx, workspaces::empty_parse_lib_provider::instance };
 
     std::string name = "n";
     std::vector<ca_expr_ptr> subscript;
@@ -52,11 +51,10 @@ ca_symbol_attribute create_var_sym_attr(context::data_attr_kind kind, context::i
 
 TEST(ca_symbol_attr, evaluate_undef_varsym)
 {
-    auto hlasm_ctx = std::make_shared<context::hlasm_context>();
-    evaluation_context eval_ctx { analyzing_context { hlasm_ctx, std::make_shared<lsp::lsp_context>() },
-        workspaces::empty_parse_lib_provider::instance };
+    context::hlasm_context ctx;
+    evaluation_context eval_ctx { ctx, workspaces::empty_parse_lib_provider::instance };
 
-    auto res = create_var_sym_attr(context::data_attr_kind::D, hlasm_ctx->ids().add("n")).evaluate(eval_ctx);
+    auto res = create_var_sym_attr(context::data_attr_kind::D, ctx.ids().add("n")).evaluate(eval_ctx);
 
     ASSERT_EQ(eval_ctx.diags().size(), 1U);
     EXPECT_EQ(eval_ctx.diags().front().code, "E010");
@@ -64,13 +62,12 @@ TEST(ca_symbol_attr, evaluate_undef_varsym)
 
 TEST(ca_symbol_attr, evaluate_substituted_varsym_not_char)
 {
-    auto hlasm_ctx = std::make_shared<context::hlasm_context>();
-    evaluation_context eval_ctx { analyzing_context { hlasm_ctx, std::make_shared<lsp::lsp_context>() },
-        workspaces::empty_parse_lib_provider::instance };
+    context::hlasm_context ctx;
+    evaluation_context eval_ctx { ctx, workspaces::empty_parse_lib_provider::instance };
 
-    auto name = hlasm_ctx->ids().add("n");
+    auto name = ctx.ids().add("n");
 
-    auto var = hlasm_ctx->create_local_variable<int>(name, true);
+    auto var = ctx.create_local_variable<int>(name, true);
     var->access_set_symbol<int>()->set_value(12);
 
     auto res = create_var_sym_attr(context::data_attr_kind::L, name).evaluate(eval_ctx);
@@ -81,13 +78,12 @@ TEST(ca_symbol_attr, evaluate_substituted_varsym_not_char)
 
 TEST(ca_symbol_attr, evaluate_substituted_varsym_char_not_sym)
 {
-    auto hlasm_ctx = std::make_shared<context::hlasm_context>();
-    evaluation_context eval_ctx { analyzing_context { hlasm_ctx, std::make_shared<lsp::lsp_context>() },
-        workspaces::empty_parse_lib_provider::instance };
+    context::hlasm_context ctx;
+    evaluation_context eval_ctx { ctx, workspaces::empty_parse_lib_provider::instance };
 
-    auto name = hlasm_ctx->ids().add("n");
+    auto name = ctx.ids().add("n");
 
-    auto var = hlasm_ctx->create_local_variable<context::C_t>(name, true);
+    auto var = ctx.create_local_variable<context::C_t>(name, true);
     var->access_set_symbol<context::C_t>()->set_value("(abc");
 
     auto res = create_var_sym_attr(context::data_attr_kind::L, name).evaluate(eval_ctx);
@@ -119,7 +115,7 @@ class ca_attr : public ::testing::TestWithParam<attr_test_param>
 {
 protected:
     std::shared_ptr<context::hlasm_context> hlasm_ctx = std::make_shared<context::hlasm_context>();
-    evaluation_context eval_ctx { analyzing_context { hlasm_ctx, std::make_shared<lsp::lsp_context>() },
+    evaluation_context eval_ctx { *hlasm_ctx,
         workspaces::empty_parse_lib_provider::instance };
 };
 

--- a/parser_library/test/expressions/ca_symbol_test.cpp
+++ b/parser_library/test/expressions/ca_symbol_test.cpp
@@ -24,9 +24,8 @@ using namespace hlasm_plugin::parser_library;
 
 TEST(ca_symbol, undefined_attributes)
 {
-    evaluation_context eval_ctx { analyzing_context { std::make_shared<context::hlasm_context>(),
-                                      std::make_shared<lsp::lsp_context>() },
-        workspaces::empty_parse_lib_provider::instance };
+    context::hlasm_context ctx;
+    evaluation_context eval_ctx { ctx, workspaces::empty_parse_lib_provider::instance };
     std::string name = "n";
 
     ca_symbol sym(&name, range());

--- a/parser_library/test/expressions/ca_var_sym_test.cpp
+++ b/parser_library/test/expressions/ca_var_sym_test.cpp
@@ -25,9 +25,8 @@ using namespace hlasm_plugin::parser_library;
 
 TEST(ca_var_sym_basic, undefined_attributes)
 {
-    evaluation_context eval_ctx { analyzing_context { std::make_shared<context::hlasm_context>(),
-                                      std::make_shared<lsp::lsp_context>() },
-        workspaces::empty_parse_lib_provider::instance };
+    context::hlasm_context ctx;
+    evaluation_context eval_ctx { ctx, workspaces::empty_parse_lib_provider::instance };
 
     std::string name = "n";
     std::vector<ca_expr_ptr> subscript;
@@ -45,9 +44,8 @@ TEST(ca_var_sym_basic, undefined_attributes)
 
 TEST(ca_var_sym_created, undefined_attributes)
 {
-    evaluation_context eval_ctx { analyzing_context { std::make_shared<context::hlasm_context>(),
-                                      std::make_shared<lsp::lsp_context>() },
-        workspaces::empty_parse_lib_provider::instance };
+    context::hlasm_context ctx;
+    evaluation_context eval_ctx { ctx, workspaces::empty_parse_lib_provider::instance };
 
     std::string name = "n";
     concat_chain created_name;

--- a/parser_library/test/processing/lookahead_test.cpp
+++ b/parser_library/test/processing/lookahead_test.cpp
@@ -193,7 +193,7 @@ TEST(attribute_lookahead, lookup_triggered)
     analyzer a(input);
     auto& expr = a.parser().expr()->ca_expr;
 
-    evaluation_context eval_ctx { analyzing_context { a.context() }, workspaces::empty_parse_lib_provider::instance };
+    evaluation_context eval_ctx { a.hlasm_ctx(), workspaces::empty_parse_lib_provider::instance };
 
     EXPECT_EQ(expr->get_undefined_attributed_symbols(eval_ctx).size(), (size_t)1);
 
@@ -206,7 +206,7 @@ TEST(attribute_lookahead, nested_lookup_triggered)
     analyzer a(input);
     auto& expr = a.parser().expr()->ca_expr;
 
-    evaluation_context eval_ctx { analyzing_context { a.context() }, workspaces::empty_parse_lib_provider::instance };
+    evaluation_context eval_ctx { a.hlasm_ctx(), workspaces::empty_parse_lib_provider::instance };
 
     auto v1 = a.hlasm_ctx().create_local_variable<context::C_t>(a.hlasm_ctx().ids().add("V1"), false);
     v1->access_set_symbol<context::C_t>()->set_value("A", 0);
@@ -235,7 +235,7 @@ TEST(attribute_lookahead, lookup_not_triggered)
     analyzer a(input);
     auto& expr = a.parser().expr()->ca_expr;
 
-    evaluation_context eval_ctx { analyzing_context { a.context() }, workspaces::empty_parse_lib_provider::instance };
+    evaluation_context eval_ctx { a.hlasm_ctx(), workspaces::empty_parse_lib_provider::instance };
 
     // define symbol with undefined length
     auto tmp = a.hlasm_ctx().ord_ctx.create_symbol(
@@ -254,7 +254,7 @@ TEST(attribute_lookahead, lookup_of_two_refs)
     analyzer a(input);
     auto& expr = a.parser().expr()->ca_expr;
 
-    evaluation_context eval_ctx { analyzing_context { a.context() }, workspaces::empty_parse_lib_provider::instance };
+    evaluation_context eval_ctx { a.hlasm_ctx(), workspaces::empty_parse_lib_provider::instance };
 
     EXPECT_EQ(expr->get_undefined_attributed_symbols(eval_ctx).size(), (size_t)2);
 
@@ -267,7 +267,7 @@ TEST(attribute_lookahead, lookup_of_two_refs_but_one_symbol)
     analyzer a(input);
     auto& expr = a.parser().expr()->ca_expr;
 
-    evaluation_context eval_ctx { analyzing_context { a.context() }, workspaces::empty_parse_lib_provider::instance };
+    evaluation_context eval_ctx { a.hlasm_ctx(), workspaces::empty_parse_lib_provider::instance };
 
     EXPECT_EQ(expr->get_undefined_attributed_symbols(eval_ctx).size(), (size_t)1);
 

--- a/parser_library/test/workspace/CMakeLists.txt
+++ b/parser_library/test/workspace/CMakeLists.txt
@@ -17,6 +17,7 @@ target_sources(library_test PRIVATE
 	file_with_text.h
 	load_config_test.cpp
 	macro_cache_test.cpp
+	processor_file_test.cpp
 	text_synchronization_test.cpp
 	workspace_test.cpp
 )

--- a/parser_library/test/workspace/macro_cache_test.cpp
+++ b/parser_library/test/workspace/macro_cache_test.cpp
@@ -102,12 +102,12 @@ struct file_manager_cache_test_mock : public file_manager_impl, public parse_lib
 
 analyzing_context create_analyzing_context(std::string file_name, context::id_storage ids)
 {
+    auto hlasm_ctx = std::make_shared<context::hlasm_context>(std::move(file_name), asm_option(), std::move(ids));
     analyzing_context new_ctx {
-        std::make_shared<context::hlasm_context>(std::move(file_name), asm_option(), std::move(ids)),
-        std::make_shared<lsp::lsp_context>(),
+        hlasm_ctx,
+        std::make_shared<lsp::lsp_context>(hlasm_ctx),
     };
-    lsp::opencode_info_ptr oip =
-        std::make_unique<lsp::opencode_info>(*new_ctx.hlasm_ctx, lsp::vardef_storage(), lsp::file_occurences_t {});
+    lsp::opencode_info_ptr oip = std::make_unique<lsp::opencode_info>(lsp::vardef_storage(), lsp::file_occurences_t {});
     new_ctx.lsp_ctx->add_opencode(std::move(oip), lsp::text_data_ref_t(""));
 
     return new_ctx;

--- a/parser_library/test/workspace/macro_cache_test.cpp
+++ b/parser_library/test/workspace/macro_cache_test.cpp
@@ -22,6 +22,7 @@
 #include "file_with_text.h"
 #include "workspaces/file_manager_impl.h"
 #include "workspaces/processor_file_impl.h"
+#include "workspaces/workspace.h"
 
 
 using namespace hlasm_plugin::parser_library;
@@ -304,6 +305,47 @@ MAC OPSYN AREAD
     EXPECT_EQ(state, expected);
 }
 
+namespace {
+std::optional<diagnostic_s> find_diag_with_filename(
+    const std::vector<diagnostic_s>& diags, const std::string& file_name)
+{
+    auto macro_diag =
+        std::find_if(diags.begin(), diags.end(), [&](const diagnostic_s& d) { return d.file_name == file_name; });
+    if (macro_diag == diags.end())
+        return std::nullopt;
+    else
+        return *macro_diag;
+}
+
+struct files_parse_lib_provider : public parse_lib_provider
+{
+    file_manager* file_mngr;
+    files_parse_lib_provider(file_manager& mngr)
+        : file_mngr(&mngr)
+    {}
+    virtual parse_result parse_library(const std::string& library, analyzing_context ctx, library_data data) override
+    {
+        auto macro = file_mngr->add_processor_file(library);
+        if (!macro)
+            return false;
+        return macro->parse_macro(*this, std::move(ctx), std::move(data));
+    }
+    virtual bool has_library(const std::string& library, const std::string& program) const override
+    {
+        return file_mngr->find(library) != nullptr;
+    }
+    virtual std::optional<std::string> get_library(
+        const std::string& library, const std::string& program, std::string* file_uri) const override
+    {
+        auto macro = file_mngr->add_processor_file(library);
+        if (!macro)
+            return std::nullopt;
+        return macro->get_text();
+    }
+};
+
+} // namespace
+
 TEST(macro_cache_test, overwrite_by_inline)
 {
     std::string opencode_file_name = "opencode";
@@ -318,7 +360,7 @@ TEST(macro_cache_test, overwrite_by_inline)
        
        MAC
 )";
-    std::string macro_file_name = "lib/MAC";
+    std::string macro_file_name = "MAC";
     std::string macro_text =
         R"( MACRO
        MAC
@@ -326,28 +368,28 @@ TEST(macro_cache_test, overwrite_by_inline)
        MEND
 )";
 
-    file_manager_cache_test_mock file_mngr;
-    auto opencode = file_mngr.add_opencode(opencode_file_name, opencode_text);
-    auto& [macro, macro_c] = file_mngr.add_macro_or_copy(macro_file_name, macro_text);
+    file_manager_impl file_mngr;
+    lib_config global_config;
+    files_parse_lib_provider lib_provider(file_mngr);
 
-    opencode->parse(file_mngr, {}, {});
+    file_mngr.did_open_file(opencode_file_name, 0, opencode_text);
+    file_mngr.did_open_file(macro_file_name, 0, macro_text);
+    auto opencode = file_mngr.add_processor_file(opencode_file_name);
+
+    opencode->parse(lib_provider, {}, {});
     opencode->collect_diags();
+
+    EXPECT_EQ(opencode->diags().size(), 2U);
+    EXPECT_TRUE(find_diag_with_filename(opencode->diags(), macro_file_name));
+    EXPECT_TRUE(find_diag_with_filename(opencode->diags(), opencode_file_name));
+
     opencode->diags().clear();
 
-    opencode->parse(file_mngr, {}, {});
+    opencode->parse(lib_provider, {}, {});
     opencode->collect_diags();
     EXPECT_EQ(opencode->diags().size(), 2U);
-
-
-    auto macro_diag = std::find_if(opencode->diags().begin(), opencode->diags().end(), [&](const diagnostic_s& d) {
-        return d.file_name == macro_file_name;
-    });
-    EXPECT_NE(macro_diag, opencode->diags().end());
-
-    auto opencode_diag = std::find_if(opencode->diags().begin(), opencode->diags().end(), [&](const diagnostic_s& d) {
-        return d.file_name == opencode_file_name;
-    });
-    EXPECT_NE(opencode_diag, opencode->diags().end());
+    EXPECT_TRUE(find_diag_with_filename(opencode->diags(), macro_file_name));
+    EXPECT_TRUE(find_diag_with_filename(opencode->diags(), opencode_file_name));
 }
 
 TEST(macro_cache_test, inline_depends_on_copy)

--- a/parser_library/test/workspace/processor_file_test.cpp
+++ b/parser_library/test/workspace/processor_file_test.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2021 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Broadcom, Inc. - initial API and implementation
+ */
+
+#include "gtest/gtest.h"
+
+#include "workspaces/file_manager_impl.h"
+#include "workspaces/processor_file_impl.h"
+
+using namespace hlasm_plugin::parser_library;
+using namespace hlasm_plugin::parser_library::workspaces;
+TEST(processor_file, empty_file_feature_provider)
+{
+    std::string file_name = "filename";
+    file_manager_impl mngr;
+    mngr.did_open_file(file_name, 0, " LR 1,1");
+    auto file = mngr.add_processor_file(file_name);
+
+    // Prior to parsing, it should return default values;
+
+    auto& fp = file->get_lsp_feature_provider();
+
+    EXPECT_EQ(fp.definition(file_name, { 0, 5 }), location({ 0, 5 }, file_name));
+    EXPECT_EQ(fp.references(file_name, { 0, 5 }), location_list());
+    EXPECT_EQ(fp.hover(file_name, { 0, 5 }), "");
+    EXPECT_EQ(fp.completion(file_name, { 0, 5 }, '\0', completion_trigger_kind::invoked), lsp::completion_list_s());
+
+    EXPECT_EQ(file->get_hl_info(), semantics::lines_info());
+    EXPECT_EQ(file->get_metrics(), performance_metrics());
+}

--- a/parser_library/test/workspace/workspace_test.cpp
+++ b/parser_library/test/workspace/workspace_test.cpp
@@ -80,7 +80,6 @@ TEST_F(workspace_test, parse_lib_provider)
 
     file_mngr.add_processor_file("test\\library\\test_wks\\correct");
 
-    auto lsp_ptr = std::make_shared<lsp::lsp_context>();
     auto [ctx_1, ctx_2] = [&ws]() {
         if (platform::is_windows())
         {
@@ -102,7 +101,7 @@ TEST_F(workspace_test, parse_lib_provider)
     diags().clear();
 
     ws.parse_library("MACRO1",
-        analyzing_context { ctx_1, lsp_ptr },
+        analyzing_context { ctx_1, std::make_shared<lsp::lsp_context>(ctx_1) },
         library_data { processing::processing_kind::MACRO, ctx_1->ids().add("MACRO1") });
 
     // test, that macro1 is parsed, once we are able to parse macros (mby in ctx)
@@ -111,7 +110,7 @@ TEST_F(workspace_test, parse_lib_provider)
     EXPECT_EQ(diags().size(), (size_t)0);
 
     ws.parse_library("not_existing",
-        analyzing_context { ctx_2, lsp_ptr },
+        analyzing_context { ctx_2, std::make_shared<lsp::lsp_context>(ctx_2) },
         library_data { processing::processing_kind::MACRO, ctx_2->ids().add("not_existing") });
 }
 


### PR DESCRIPTION
fix: inline macros overwriting external definition stored in macro cache
refactor: evaluation context does not need lsp context, only hlasm context
fix: crash when `processor_file` is queried for information prior to first parse