### PR TITLE
fix: Syntax errors reported in bilingual macros

### DIFF
--- a/parser_library/src/CMakeLists.txt
+++ b/parser_library/src/CMakeLists.txt
@@ -18,6 +18,7 @@ target_sources(parser_library PRIVATE
 	analyzing_context.h
 	compiler_options.h
 	diagnosable.h
+	diagnosable_ctx.cpp
 	diagnosable_ctx.h
 	diagnosable_impl.h
 	diagnostic.cpp

--- a/parser_library/src/checking/diagnostic_collector.cpp
+++ b/parser_library/src/checking/diagnostic_collector.cpp
@@ -35,7 +35,7 @@ void diagnostic_collector::operator()(diagnostic_op diagnostic) const
 {
     if (!diagnoser_)
         return;
-    diagnoser_->add_diagnostic_inner(std::move(diagnostic), get_location_stack());
+    diagnoser_->diagnosable_impl::add_diagnostic(add_stack_details(std::move(diagnostic), get_location_stack()));
 }
 
 context::processing_stack_t diagnostic_collector::get_location_stack() const

--- a/parser_library/src/context/hlasm_statement.h
+++ b/parser_library/src/context/hlasm_statement.h
@@ -28,6 +28,7 @@ namespace hlasm_plugin::parser_library::semantics {
 struct deferred_statement;
 } // namespace hlasm_plugin::parser_library::semantics
 namespace hlasm_plugin::parser_library::processing {
+class error_statement;
 struct resolved_statement;
 } // namespace hlasm_plugin::parser_library::processing
 
@@ -42,7 +43,8 @@ using statement_block = std::vector<shared_stmt_ptr>;
 enum class statement_kind
 {
     RESOLVED,
-    DEFERRED
+    DEFERRED,
+    ERROR,
 };
 
 // abstract structure representing general HLASM statement
@@ -58,7 +60,7 @@ struct hlasm_statement
 
     virtual position statement_position() const = 0;
 
-    virtual std::pair<const diagnostic_op*, const diagnostic_op*> diagnostics() const { return {}; }
+    virtual std::pair<const diagnostic_op*, const diagnostic_op*> diagnostics() const = 0;
 
     virtual ~hlasm_statement() = default;
 

--- a/parser_library/src/context/hlasm_statement.h
+++ b/parser_library/src/context/hlasm_statement.h
@@ -16,10 +16,14 @@
 #define CONTEXT_HLASM_STATEMENT_H
 
 #include <memory>
+#include <utility>
 #include <vector>
 
 #include "range.h"
 
+namespace hlasm_plugin::parser_library {
+struct diagnostic_op;
+} // namespace hlasm_plugin::parser_library
 namespace hlasm_plugin::parser_library::semantics {
 struct deferred_statement;
 } // namespace hlasm_plugin::parser_library::semantics
@@ -53,6 +57,8 @@ struct hlasm_statement
     semantics::deferred_statement* access_deferred();
 
     virtual position statement_position() const = 0;
+
+    virtual std::pair<const diagnostic_op*, const diagnostic_op*> diagnostics() const { return {}; }
 
     virtual ~hlasm_statement() = default;
 

--- a/parser_library/src/debugging/debugger.cpp
+++ b/parser_library/src/debugging/debugger.cpp
@@ -170,11 +170,16 @@ public:
         // lookahead and copy/macro definitions)
         if (proc_kind != processing::processing_kind::ORDINARY)
             return;
-        // Continue only for non-empty statements
-        if (statement.access_resolved()->opcode_ref().value == context::id_storage::empty_id)
+
+        const auto* resolved_stmt = statement.access_resolved();
+        if (!resolved_stmt)
             return;
 
-        range stmt_range = statement.access_resolved()->stmt_range_ref();
+        // Continue only for non-empty statements
+        if (resolved_stmt->opcode_ref().value == context::id_storage::empty_id)
+            return;
+
+        range stmt_range = resolved_stmt->stmt_range_ref();
 
         bool breakpoint_hit = false;
 

--- a/parser_library/src/diagnosable_ctx.cpp
+++ b/parser_library/src/diagnosable_ctx.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2021 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Broadcom, Inc. - initial API and implementation
+ */
+
+#include "diagnosable_ctx.h"
+
+namespace hlasm_plugin::parser_library {
+
+void diagnosable_ctx::add_diagnostic(diagnostic_s diagnostic) const
+{
+    diagnosable_impl::add_diagnostic(add_stack_details(
+        diagnostic_op(
+            diagnostic.severity, std::move(diagnostic.code), std::move(diagnostic.message), diagnostic.diag_range),
+        ctx_.processing_stack()));
+}
+
+void diagnosable_ctx::add_diagnostic(diagnostic_op diagnostic) const
+{
+    diagnosable_impl::add_diagnostic(add_stack_details(std::move(diagnostic), ctx_.processing_stack()));
+}
+
+diagnostic_s add_stack_details(diagnostic_op diagnostic, context::processing_stack_t stack)
+{
+    diagnostic_s diag(std::move(stack.back().proc_location.file), std::move(diagnostic));
+
+    diag.related.reserve(stack.size() - 1);
+    for (auto frame = ++stack.rbegin(); frame != stack.rend(); ++frame)
+    {
+        auto& file_name = frame->proc_location.file;
+        auto message = "While compiling " + file_name + '(' + std::to_string(frame->proc_location.pos.line + 1) + ")";
+        diag.related.emplace_back(
+            range_uri_s(std::move(file_name), range(frame->proc_location.pos, frame->proc_location.pos)),
+            std::move(message));
+    }
+
+    return diag;
+}
+
+} // namespace hlasm_plugin::parser_library

--- a/parser_library/src/diagnosable_ctx.h
+++ b/parser_library/src/diagnosable_ctx.h
@@ -28,44 +28,20 @@ class diagnosable_ctx : public diagnosable_impl, public diagnostic_op_consumer
     context::hlasm_context& ctx_;
 
 public:
-    void add_diagnostic(diagnostic_s diagnostic) const override
-    {
-        add_diagnostic_inner(
-            diagnostic_op(
-                diagnostic.severity, std::move(diagnostic.code), std::move(diagnostic.message), diagnostic.diag_range),
-            ctx_.processing_stack());
-    }
-
-    void add_diagnostic(diagnostic_op diagnostic) const override
-    {
-        add_diagnostic_inner(std::move(diagnostic), ctx_.processing_stack());
-    }
+    void add_diagnostic(diagnostic_s diagnostic) const override;
+    void add_diagnostic(diagnostic_op diagnostic) const override;
 
 protected:
     diagnosable_ctx(context::hlasm_context& ctx)
         : ctx_(ctx)
     {}
 
-    virtual ~diagnosable_ctx() {};
-
-private:
-    void add_diagnostic_inner(diagnostic_op diagnostic, const context::processing_stack_t& stack) const
-    {
-        diagnostic_s diag(stack.back().proc_location.file, diagnostic);
-
-        for (auto frame = ++stack.rbegin(); frame != stack.rend(); ++frame)
-        {
-            auto& file_name = frame->proc_location.file;
-            range r = range(frame->proc_location.pos, frame->proc_location.pos);
-            diagnostic_related_info_s s = diagnostic_related_info_s(range_uri_s(file_name, r),
-                "While compiling " + file_name + '(' + std::to_string(frame->proc_location.pos.line + 1) + ")");
-            diag.related.push_back(std::move(s));
-        }
-        diagnosable_impl::add_diagnostic(std::move(diag));
-    }
+    virtual ~diagnosable_ctx() = default;
 
     friend diagnostic_collector;
 };
+
+diagnostic_s add_stack_details(diagnostic_op diagnostic, context::processing_stack_t stack);
 
 } // namespace hlasm_plugin::parser_library
 

--- a/parser_library/src/diagnostic.cpp
+++ b/parser_library/src/diagnostic.cpp
@@ -1676,6 +1676,26 @@ diagnostic_op diagnostic_op::error_E043(const range& range)
     return diagnostic_op(diagnostic_severity::error, "E043", "Invalid name of variable in macro prototype", range);
 }
 
+diagnostic_op diagnostic_op::error_E044(const range& range)
+{
+    return diagnostic_op(diagnostic_severity::error, "E044", "Illegal name field in macro prototype, discarded", range);
+}
+
+diagnostic_op diagnostic_op::error_E045(const std::string& message, const range& range)
+{
+    return diagnostic_op(diagnostic_severity::error, "E045", "Sequence symbol already defined - " + message, range);
+}
+
+diagnostic_op diagnostic_op::error_E046(const std::string& message, const range& range)
+{
+    return diagnostic_op(diagnostic_severity::error, "E046", "Missing MEND in " + message, range);
+}
+
+diagnostic_op diagnostic_op::error_E047(const std::string& message, const range& range)
+{
+    return diagnostic_op(diagnostic_severity::error, "E047", "Lookahead failed, symbol not found - " + message, range);
+}
+
 diagnostic_op diagnostic_op::error_E048(const std::string& message, const range& range)
 {
     return diagnostic_op(
@@ -1798,24 +1818,9 @@ diagnostic_op diagnostic_op::error_E070(const range& range)
         diagnostic_severity::error, "E070", "Invalid AREAD operand. Use AREAD [NOSTMT|NOPRINT|CLOCKB|CLOCKD].", range);
 }
 
-diagnostic_op diagnostic_op::error_E044(const range& range)
+diagnostic_op diagnostic_op::error_E071(const range& range)
 {
-    return diagnostic_op(diagnostic_severity::error, "E044", "Illegal name field in macro prototype, discarded", range);
-}
-
-diagnostic_op diagnostic_op::error_E045(const std::string& message, const range& range)
-{
-    return diagnostic_op(diagnostic_severity::error, "E045", "Sequence symbol already defined - " + message, range);
-}
-
-diagnostic_op diagnostic_op::error_E046(const std::string& message, const range& range)
-{
-    return diagnostic_op(diagnostic_severity::error, "E046", "Missing MEND in " + message, range);
-}
-
-diagnostic_op diagnostic_op::error_E047(const std::string& message, const range& range)
-{
-    return diagnostic_op(diagnostic_severity::error, "E047", "Lookahead failed, symbol not found - " + message, range);
+    return diagnostic_op(diagnostic_severity::error, "E071", "Macro prototype expected.", range);
 }
 
 diagnostic_op diagnostic_op::warning_W010(const std::string& message, const range& range)

--- a/parser_library/src/diagnostic.h
+++ b/parser_library/src/diagnostic.h
@@ -570,6 +570,8 @@ struct diagnostic_op
 
     static diagnostic_op error_E070(const range& range);
 
+    static diagnostic_op error_E071(const range& range);
+
     static diagnostic_op warning_W010(const std::string& message, const range& range);
 
     static diagnostic_op warning_W011(const range& range);

--- a/parser_library/src/parsing/parser_impl.cpp
+++ b/parser_library/src/parsing/parser_impl.cpp
@@ -149,14 +149,14 @@ void parser_impl::resolve_expression(expressions::ca_expr_ptr& expr) const
     else if (opcode.value == hlasm_ctx->ids().well_known.SETB)
     {
         if (!expr->is_compatible(ca_expression_compatibility::setb))
-            expr->diags().push_back(diagnostic_op::error_CE016_logical_expression_parenthesis(expr->expr_range));
+            expr->add_diagnostic(diagnostic_op::error_CE016_logical_expression_parenthesis(expr->expr_range));
 
         resolve_expression(expr, context::SET_t_enum::B_TYPE);
     }
     else if (opcode.value == hlasm_ctx->ids().well_known.AIF)
     {
         if (!expr->is_compatible(ca_expression_compatibility::aif))
-            expr->diags().push_back(diagnostic_op::error_CE016_logical_expression_parenthesis(expr->expr_range));
+            expr->add_diagnostic(diagnostic_op::error_CE016_logical_expression_parenthesis(expr->expr_range));
 
         resolve_expression(expr, context::SET_t_enum::B_TYPE);
     }

--- a/parser_library/src/parsing/parser_impl.h
+++ b/parser_library/src/parsing/parser_impl.h
@@ -53,6 +53,12 @@ public:
         processing::processing_status proc_stat,
         diagnostic_op_consumer* diagnoser);
 
+    void set_diagnoser(diagnostic_op_consumer* diagnoser)
+    {
+        diagnoser_ = diagnoser;
+        err_listener_.diagnoser = diagnoser;
+    }
+
     semantics::collector& get_collector() { return collector; }
 
 protected:

--- a/parser_library/src/processing/CMakeLists.txt
+++ b/parser_library/src/processing/CMakeLists.txt
@@ -15,6 +15,8 @@ target_sources(parser_library PRIVATE
 	context_manager.cpp
 	context_manager.h
 	db2_preprocessor.cpp
+	error_statement.cpp
+	error_statement.h
 	op_code.h
 	opencode_provider.cpp
 	opencode_provider.h

--- a/parser_library/src/processing/error_statement.cpp
+++ b/parser_library/src/processing/error_statement.cpp
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2021 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Broadcom, Inc. - initial API and implementation
+ */
+
+#include "error_statement.h"
+
+
+namespace hlasm_plugin::parser_library::processing {
+
+
+position error_statement::statement_position() const { return m_range.start; }
+
+std::pair<const diagnostic_op*, const diagnostic_op*> error_statement::diagnostics() const
+{
+    return { m_errors.data(), m_errors.data() + m_errors.size() };
+}
+
+} // namespace hlasm_plugin::parser_library::processing

--- a/parser_library/src/processing/error_statement.h
+++ b/parser_library/src/processing/error_statement.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2021 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Broadcom, Inc. - initial API and implementation
+ */
+
+#ifndef HLASMPARSER_PARSERLIBRARY_PROCESSING_ERROR_STATEMENT_H
+#define HLASMPARSER_PARSERLIBRARY_PROCESSING_ERROR_STATEMENT_H
+
+#include "context/hlasm_statement.h"
+#include "diagnostic.h"
+
+namespace hlasm_plugin::parser_library::processing {
+
+class error_statement : public context::hlasm_statement
+{
+    std::vector<diagnostic_op> m_errors;
+    range m_range;
+
+public:
+    error_statement(range r, std::vector<diagnostic_op>&& diags)
+        : hlasm_statement(context::statement_kind::ERROR)
+        , m_errors(std::make_move_iterator(diags.begin()), std::make_move_iterator(diags.end()))
+        , m_range(r)
+    {}
+
+    position statement_position() const override;
+
+    std::pair<const diagnostic_op*, const diagnostic_op*> diagnostics() const override;
+};
+
+} // namespace hlasm_plugin::parser_library::processing
+
+#endif // HLASMPARSER_PARSERLIBRARY_PROCESSING_ERROR_STATEMENT_H

--- a/parser_library/src/processing/instruction_sets/asm_processor.cpp
+++ b/parser_library/src/processing/instruction_sets/asm_processor.cpp
@@ -501,7 +501,7 @@ asm_processor::asm_processor(analyzing_context ctx,
     , open_code_(&open_code)
 {}
 
-void asm_processor::process(context::shared_stmt_ptr stmt)
+void asm_processor::process(std::shared_ptr<const processing::resolved_statement> stmt)
 {
     auto rebuilt_stmt = preprocess(stmt);
 

--- a/parser_library/src/processing/instruction_sets/asm_processor.h
+++ b/parser_library/src/processing/instruction_sets/asm_processor.h
@@ -37,7 +37,7 @@ public:
         statement_fields_parser& parser,
         opencode_provider& open_code);
 
-    void process(context::shared_stmt_ptr stmt) override;
+    void process(std::shared_ptr<const processing::resolved_statement> stmt) override;
 
     static bool process_copy(const semantics::complete_statement& stmt,
         analyzing_context ctx,

--- a/parser_library/src/processing/instruction_sets/ca_processor.cpp
+++ b/parser_library/src/processing/instruction_sets/ca_processor.cpp
@@ -33,11 +33,10 @@ ca_processor::ca_processor(analyzing_context ctx,
     , open_code_(&open_code)
 {}
 
-void ca_processor::process(context::shared_stmt_ptr stmt)
+void ca_processor::process(std::shared_ptr<const processing::resolved_statement> stmt)
 {
-    auto res = stmt->access_resolved();
-    auto& func = table_.at(res->opcode_ref().value);
-    func(*res);
+    auto& func = table_.at(stmt->opcode_ref().value);
+    func(*stmt);
 }
 
 ca_processor::process_table_t ca_processor::create_table(context::hlasm_context& h_ctx)

--- a/parser_library/src/processing/instruction_sets/ca_processor.h
+++ b/parser_library/src/processing/instruction_sets/ca_processor.h
@@ -40,7 +40,7 @@ public:
         processing_state_listener& listener,
         opencode_provider& open_code);
 
-    void process(context::shared_stmt_ptr stmt) override;
+    void process(std::shared_ptr<const processing::resolved_statement> stmt) override;
 
 private:
     opencode_provider* open_code_;

--- a/parser_library/src/processing/instruction_sets/instruction_processor.h
+++ b/parser_library/src/processing/instruction_sets/instruction_processor.h
@@ -30,7 +30,7 @@ namespace hlasm_plugin::parser_library::processing {
 // processing is divided into classes for assembler, conditional assembly, machine, macro instruction processing
 class instruction_processor : public diagnosable_ctx
 {
-    virtual void process(context::shared_stmt_ptr stmt) = 0;
+    virtual void process(std::shared_ptr<const processing::resolved_statement> stmt) = 0;
 
     void collect_diags() const override { collect_diags_from_child(eval_ctx); }
 

--- a/parser_library/src/processing/instruction_sets/low_language_processor.cpp
+++ b/parser_library/src/processing/instruction_sets/low_language_processor.cpp
@@ -31,7 +31,7 @@ low_language_processor::low_language_processor(analyzing_context ctx,
     , parser(parser)
 {}
 
-rebuilt_statement low_language_processor::preprocess(context::shared_stmt_ptr statement)
+rebuilt_statement low_language_processor::preprocess(std::shared_ptr<const processing::resolved_statement> statement)
 {
     auto stmt = std::static_pointer_cast<const resolved_statement>(statement);
     auto [label, ops] = preprocess_inner(*stmt);

--- a/parser_library/src/processing/instruction_sets/low_language_processor.h
+++ b/parser_library/src/processing/instruction_sets/low_language_processor.h
@@ -42,7 +42,7 @@ protected:
         workspaces::parse_lib_provider& lib_provider,
         statement_fields_parser& parser);
 
-    rebuilt_statement preprocess(context::shared_stmt_ptr stmt);
+    rebuilt_statement preprocess(std::shared_ptr<const processing::resolved_statement> stmt);
 
     // adds dependency and also check for cyclic dependency and adds diagnostics if so
     template<typename... Args>

--- a/parser_library/src/processing/instruction_sets/mach_processor.cpp
+++ b/parser_library/src/processing/instruction_sets/mach_processor.cpp
@@ -29,7 +29,7 @@ mach_processor::mach_processor(analyzing_context ctx,
     : low_language_processor(std::move(ctx), branch_provider, lib_provider, parser)
 {}
 
-void mach_processor::process(context::shared_stmt_ptr stmt)
+void mach_processor::process(std::shared_ptr<const processing::resolved_statement> stmt)
 {
     auto rebuilt_stmt = preprocess(stmt);
 
@@ -39,7 +39,7 @@ void mach_processor::process(context::shared_stmt_ptr stmt)
             return *mnemonic->second.instruction;
         else
             return context::instruction::machine_instructions.at(name);
-    }(*stmt->access_resolved()->opcode_ref().value);
+    }(*stmt->opcode_ref().value);
 
     auto label_name = find_label_symbol(rebuilt_stmt);
 

--- a/parser_library/src/processing/instruction_sets/mach_processor.h
+++ b/parser_library/src/processing/instruction_sets/mach_processor.h
@@ -30,7 +30,7 @@ public:
         workspaces::parse_lib_provider& lib_provider,
         statement_fields_parser& parser);
 
-    void process(context::shared_stmt_ptr stmt) override;
+    void process(std::shared_ptr<const processing::resolved_statement> stmt) override;
 };
 
 } // namespace hlasm_plugin::parser_library::processing

--- a/parser_library/src/processing/instruction_sets/macro_processor.cpp
+++ b/parser_library/src/processing/instruction_sets/macro_processor.cpp
@@ -27,12 +27,11 @@ macro_processor::macro_processor(
     : instruction_processor(std::move(ctx), branch_provider, lib_provider)
 {}
 
-void macro_processor::process(context::shared_stmt_ptr stmt)
+void macro_processor::process(std::shared_ptr<const processing::resolved_statement> stmt)
 {
-    auto args = get_args(*stmt->access_resolved());
+    auto args = get_args(*stmt);
 
-    hlasm_ctx.enter_macro(
-        stmt->access_resolved()->opcode_ref().value, std::move(args.name_param), std::move(args.symbolic_params));
+    hlasm_ctx.enter_macro(stmt->opcode_ref().value, std::move(args.name_param), std::move(args.symbolic_params));
 }
 
 bool is_data_def(unsigned char c)

--- a/parser_library/src/processing/instruction_sets/macro_processor.h
+++ b/parser_library/src/processing/instruction_sets/macro_processor.h
@@ -34,7 +34,7 @@ public:
     macro_processor(
         analyzing_context ctx, branching_provider& branch_provider, workspaces::parse_lib_provider& lib_provider);
 
-    void process(context::shared_stmt_ptr stmt) override;
+    void process(std::shared_ptr<const processing::resolved_statement> stmt) override;
 
     static context::macro_data_ptr string_to_macrodata(std::string data);
 

--- a/parser_library/src/processing/instruction_sets/postponed_statement_impl.h
+++ b/parser_library/src/processing/instruction_sets/postponed_statement_impl.h
@@ -42,6 +42,8 @@ struct postponed_statement_impl : public context::postponed_statement, public re
     processing_format format_ref() const override { return stmt.format_ref(); }
 
     const context::processing_stack_t& location_stack() const override { return stmt_location_stack; }
+
+    std::pair<const diagnostic_op*, const diagnostic_op*> diagnostics() const override { return stmt.diagnostics(); }
 };
 
 } // namespace hlasm_plugin::parser_library::processing

--- a/parser_library/src/processing/opencode_provider.cpp
+++ b/parser_library/src/processing/opencode_provider.cpp
@@ -19,6 +19,7 @@
 #include "lexing/token_stream.h"
 #include "parsing/error_strategy.h"
 #include "parsing/parser_impl.h"
+#include "processing/error_statement.h"
 #include "semantics/collector.h"
 #include "semantics/range_provider.h"
 
@@ -450,13 +451,11 @@ context::shared_stmt_ptr opencode_provider::get_next(const statement_processor& 
 
     if (!collector.has_instruction())
     {
-        if (lookahead || !nested)
+        if (lookahead)
             return nullptr;
         else
-            return std::make_shared<semantics::statement_si_deferred>(range {},
-                semantics::label_si { {} },
-                semantics::instruction_si { {} },
-                semantics::deferred_operands_si { {}, {}, {} },
+            return std::make_shared<processing::error_statement>(
+                range(position(m_current_logical_line_source.begin_line, 0)),
                 std::move(collector.diag_container().diags));
     }
 

--- a/parser_library/src/processing/opencode_provider.h
+++ b/parser_library/src/processing/opencode_provider.h
@@ -154,14 +154,14 @@ private:
     void generate_aread_highlighting(std::string_view text, size_t line_no) const;
     bool is_next_line_ictl() const;
     bool is_next_line_process() const;
-    void generate_continuation_error_messages() const;
+    void generate_continuation_error_messages(diagnostic_op_consumer* diags) const;
     extract_next_logical_line_result extract_next_logical_line_from_ainsert_buffer();
     extract_next_logical_line_result extract_next_logical_line_from_copy_buffer();
     extract_next_logical_line_result extract_next_logical_line();
     void apply_pending_line_changes();
     const parsing::parser_holder& prepare_operand_parser(const std::string& text,
         context::hlasm_context& hlasm_ctx,
-        bool do_collect_diags,
+        diagnostic_op_consumer* diag_collector,
         semantics::range_provider range_prov,
         range text_range,
         const processing_status& proc_status,
@@ -174,7 +174,8 @@ private:
     std::shared_ptr<const context::hlasm_statement> process_ordinary(const statement_processor& proc,
         semantics::collector& collector,
         const std::optional<std::string>& op_text,
-        const range& op_range);
+        const range& op_range,
+        diagnostic_op_consumer* diags);
 
     bool fill_copy_buffer_for_aread();
     bool try_running_preprocessor();

--- a/parser_library/src/processing/statement.h
+++ b/parser_library/src/processing/statement.h
@@ -44,9 +44,17 @@ struct resolved_statement_impl : public resolved_statement
         : base_stmt(std::move(base_stmt))
         , status(std::move(status))
     {}
+    resolved_statement_impl(std::shared_ptr<const semantics::complete_statement> base_stmt,
+        processing_status status,
+        std::vector<diagnostic_op>&& diags)
+        : base_stmt(std::move(base_stmt))
+        , status(std::move(status))
+        , statement_diagnostics(std::make_move_iterator(diags.begin()), std::make_move_iterator(diags.end()))
+    {}
 
     std::shared_ptr<const semantics::complete_statement> base_stmt;
     processing_status status;
+    std::vector<diagnostic_op> statement_diagnostics;
 
     const semantics::label_si& label_ref() const override { return base_stmt->label_ref(); }
     const semantics::instruction_si& instruction_ref() const override { return base_stmt->instruction_ref(); }
@@ -55,6 +63,10 @@ struct resolved_statement_impl : public resolved_statement
     const range& stmt_range_ref() const override { return base_stmt->stmt_range_ref(); }
     const op_code& opcode_ref() const override { return status.second; }
     processing_format format_ref() const override { return status.first; }
+    std::pair<const diagnostic_op*, const diagnostic_op*> diagnostics() const override
+    {
+        return { statement_diagnostics.data(), statement_diagnostics.data() + statement_diagnostics.size() };
+    }
 };
 
 // statement used for preprocessing of resolved statements

--- a/parser_library/src/processing/statement.h
+++ b/parser_library/src/processing/statement.h
@@ -97,6 +97,12 @@ struct rebuilt_statement : public resolved_statement
     const range& stmt_range_ref() const override { return base_stmt->stmt_range_ref(); }
     const op_code& opcode_ref() const override { return base_stmt->opcode_ref(); }
     processing_format format_ref() const override { return base_stmt->format_ref(); }
+
+
+    std::pair<const diagnostic_op*, const diagnostic_op*> diagnostics() const override
+    {
+        return base_stmt->diagnostics();
+    }
 };
 
 } // namespace hlasm_plugin::parser_library::processing

--- a/parser_library/src/processing/statement_analyzers/lsp_analyzer.h
+++ b/parser_library/src/processing/statement_analyzers/lsp_analyzer.h
@@ -63,8 +63,8 @@ private:
     void collect_occurence(const semantics::operands_si& operands, occurence_collector& collector);
     void collect_occurence(const semantics::deferred_operands_si& operands, occurence_collector& collector);
 
-    void collect_var_definition(const context::hlasm_statement& statement);
-    void collect_copy_operands(const context::hlasm_statement& statement);
+    void collect_var_definition(const processing::resolved_statement& statement);
+    void collect_copy_operands(const processing::resolved_statement& statement);
 
     void collect_SET_defs(const processing::resolved_statement& statement, context::SET_t_enum type);
     void collect_LCL_GBL_defs(const processing::resolved_statement& statement, context::SET_t_enum type, bool global);
@@ -72,7 +72,7 @@ private:
 
     void add_copy_operand(context::id_index name, const range& operand_range);
 
-    void update_macro_nest(const context::hlasm_statement& statement);
+    void update_macro_nest(const processing::resolved_statement& statement);
 
     struct LCL_GBL_instr
     {

--- a/parser_library/src/processing/statement_processors/lookahead_processor.cpp
+++ b/parser_library/src/processing/statement_processors/lookahead_processor.cpp
@@ -51,19 +51,20 @@ void lookahead_processor::process_statement(context::shared_stmt_ptr statement)
         find_ord(static_cast<const resolved_statement&>(*statement));
     }
 
-    auto resolved = statement->access_resolved();
-
-    if (resolved->opcode_ref().value == macro_id)
+    if (auto resolved = statement->access_resolved())
     {
-        process_MACRO();
-    }
-    else if (resolved->opcode_ref().value == mend_id)
-    {
-        process_MEND();
-    }
-    else if (macro_nest_ == 0 && resolved->opcode_ref().value == copy_id)
-    {
-        process_COPY(*resolved);
+        if (resolved->opcode_ref().value == macro_id)
+        {
+            process_MACRO();
+        }
+        else if (resolved->opcode_ref().value == mend_id)
+        {
+            process_MEND();
+        }
+        else if (macro_nest_ == 0 && resolved->opcode_ref().value == copy_id)
+        {
+            process_COPY(*resolved);
+        }
     }
 }
 

--- a/parser_library/src/processing/statement_processors/lookahead_processor.cpp
+++ b/parser_library/src/processing/statement_processors/lookahead_processor.cpp
@@ -45,14 +45,13 @@ processing_status lookahead_processor::get_processing_status(const semantics::in
 
 void lookahead_processor::process_statement(context::shared_stmt_ptr statement)
 {
-    if (macro_nest_ == 0)
-    {
-        find_seq(static_cast<const resolved_statement&>(*statement));
-        find_ord(static_cast<const resolved_statement&>(*statement));
-    }
-
     if (auto resolved = statement->access_resolved())
     {
+        if (macro_nest_ == 0)
+        {
+            find_seq(*resolved);
+            find_ord(*resolved);
+        }
         if (resolved->opcode_ref().value == macro_id)
         {
             process_MACRO();

--- a/parser_library/src/processing/statement_processors/macrodef_processor.cpp
+++ b/parser_library/src/processing/statement_processors/macrodef_processor.cpp
@@ -94,6 +94,15 @@ void macrodef_processor::end_processing()
 
     hlasm_ctx.pop_statement_processing();
 
+    // cleanup empty file scopes
+    for (auto& scope : result_.file_scopes)
+    {
+        scope.second.erase(std::remove_if(scope.second.begin(),
+                               scope.second.end(),
+                               [](const auto& slice) { return slice.begin_statement == slice.end_statement; }),
+            scope.second.end());
+    }
+
     listener_.finish_macro_definition(std::move(result_));
 
     finished_flag_ = true;

--- a/parser_library/src/processing/statement_processors/macrodef_processor.cpp
+++ b/parser_library/src/processing/statement_processors/macrodef_processor.cpp
@@ -121,7 +121,7 @@ processing_status macrodef_processor::get_macro_processing_status(
 
             return std::make_pair(format, op_code(code.opcode, context::instruction_type::CA));
         }
-        else if (code.opcode == hlasm_ctx.ids().add("COPY"))
+        else if (code.opcode == hlasm_ctx.ids().well_known.COPY)
         {
             processing_format format(processing_kind::MACRO, processing_form::ASM, operand_occurence::PRESENT);
 
@@ -149,11 +149,11 @@ void macrodef_processor::process_statement(const context::hlasm_statement& state
 
     omit_next_ = false;
 
+    auto res_stmt = statement.access_resolved();
+
     if (expecting_MACRO_)
     {
         result_.definition_location = hlasm_ctx.processing_stack().back().proc_location;
-
-        auto res_stmt = statement.access_resolved();
 
         if (!res_stmt || res_stmt->opcode_ref().value != macro_id)
         {
@@ -168,9 +168,15 @@ void macrodef_processor::process_statement(const context::hlasm_statement& state
     }
     else if (expecting_prototype_)
     {
+        if (!res_stmt)
+        {
+            range r = res_stmt ? res_stmt->stmt_range_ref() : range(statement.statement_position());
+            add_diagnostic(diagnostic_op::error_E071(r));
+            result_.invalid = true;
+            return;
+        }
         result_.invalid = false;
-        assert(statement.access_resolved());
-        process_prototype(*statement.access_resolved());
+        process_prototype(*res_stmt);
         expecting_prototype_ = false;
     }
     else
@@ -178,7 +184,7 @@ void macrodef_processor::process_statement(const context::hlasm_statement& state
         if (hlasm_ctx.current_copy_stack().size() - initial_copy_nest_ == 0)
             curr_outer_position_ = statement.statement_position();
 
-        if (auto res_stmt = statement.access_resolved())
+        if (res_stmt)
         {
             process_sequence_symbol(res_stmt->label_ref());
 
@@ -192,10 +198,8 @@ void macrodef_processor::process_statement(const context::hlasm_statement& state
         {
             process_sequence_symbol(def_stmt->label_ref());
         }
-        else
-            assert(false);
 
-        ++curr_line_;
+        ++curr_line_; // TODO: What are we doing here???
     }
 }
 

--- a/parser_library/src/processing/statement_processors/ordinary_processor.cpp
+++ b/parser_library/src/processing/statement_processors/ordinary_processor.cpp
@@ -73,13 +73,14 @@ processing_status ordinary_processor::get_processing_status(const semantics::ins
 
 void ordinary_processor::process_statement(context::shared_stmt_ptr s)
 {
-    assert(s->kind == context::statement_kind::RESOLVED); // TODO: not sure why in principle unresolved cannot arrive
-                                                          // here
-    if (s->kind != context::statement_kind::RESOLVED)
-        return;
+    auto diags = s->diagnostics();
+    for (auto it = diags.first; it != diags.second; ++it)
+        add_diagnostic(*it);
 
     bool fatal = check_fatals(range(s->statement_position()));
     if (fatal)
+        return;
+    if (s->kind != context::statement_kind::RESOLVED)
         return;
 
     auto statement = std::static_pointer_cast<const processing::resolved_statement>(std::move(s));

--- a/parser_library/src/processing/statement_providers/members_statement_provider.cpp
+++ b/parser_library/src/processing/statement_providers/members_statement_provider.cpp
@@ -59,6 +59,9 @@ context::shared_stmt_ptr members_statement_provider::get_next(const statement_pr
         case context::statement_kind::DEFERRED:
             stmt = preprocess_deferred(processor, *cache);
             break;
+        case context::statement_kind::ERROR:
+            stmt = cache->get_base();
+            break;
         default:
             break;
     }
@@ -80,6 +83,8 @@ const semantics::instruction_si* members_statement_provider::retrieve_instructio
             return &cache.get_base()->access_resolved()->instruction_ref();
         case context::statement_kind::DEFERRED:
             return &cache.get_base()->access_deferred()->instruction_ref();
+        case context::statement_kind::ERROR:
+            return nullptr;
         default:
             return nullptr;
     }

--- a/parser_library/src/processing/statement_providers/members_statement_provider.cpp
+++ b/parser_library/src/processing/statement_providers/members_statement_provider.cpp
@@ -88,6 +88,10 @@ void members_statement_provider::fill_cache(
     context::statement_cache::cached_statement_t reparsed_stmt;
     auto def_impl = std::dynamic_pointer_cast<const semantics::statement_si_deferred>(cache.get_base());
 
+    auto diags = def_impl->diagnostics();
+    for (auto i = diags.first; i != diags.second; ++i)
+        reparsed_stmt.diags.push_back(*i);
+
     if (status.first.occurence == operand_occurence::ABSENT || status.first.form == processing_form::UNKNOWN
         || status.first.form == processing_form::IGNORED)
     {

--- a/parser_library/src/processing/statement_providers/members_statement_provider.h
+++ b/parser_library/src/processing/statement_providers/members_statement_provider.h
@@ -46,7 +46,7 @@ protected:
     virtual context::statement_cache* get_next() = 0;
 
 private:
-    const semantics::instruction_si& retrieve_instruction(const context::statement_cache& cache) const;
+    const semantics::instruction_si* retrieve_instruction(const context::statement_cache& cache) const;
 
     void fill_cache(context::statement_cache& cache,
         const semantics::deferred_statement& def_stmt,

--- a/parser_library/src/processing/statement_providers/statement_provider.cpp
+++ b/parser_library/src/processing/statement_providers/statement_provider.cpp
@@ -44,18 +44,18 @@ bool statement_provider::try_trigger_attribute_lookahead(const context::hlasm_st
     const semantics::label_si* label;
     std::set<context::id_index> references;
 
-    if (statement.kind == context::statement_kind::DEFERRED)
+    if (auto def_stmt = statement.access_deferred())
     {
-        auto def_stmt = statement.access_deferred();
         label = &def_stmt->label_ref();
     }
-    else
+    else if (auto res_stmt = statement.access_resolved())
     {
-        auto res_stmt = statement.access_resolved();
         label = &res_stmt->label_ref();
 
         references.merge(process_operands(res_stmt->operands_ref(), eval_ctx));
     }
+    else
+        return false;
 
     references.merge(process_label(*label, eval_ctx));
 

--- a/parser_library/src/semantics/collector.h
+++ b/parser_library/src/semantics/collector.h
@@ -64,6 +64,9 @@ public:
     std::vector<token_info> extract_hl_symbols();
     void prepare_for_next_statement();
 
+    diagnostic_op_consumer* diag_collector() { return &statement_diagnostics; }
+    diagnostic_op_consumer_container& diag_container() { return statement_diagnostics; }
+
 private:
     std::optional<label_si> lbl_;
     std::optional<instruction_si> instr_;
@@ -73,6 +76,8 @@ private:
     std::vector<token_info> hl_symbols_;
     bool lsp_symbols_extracted_;
     bool hl_symbols_extracted_;
+
+    diagnostic_op_consumer_container statement_diagnostics;
 
     void add_operand_remark_hl_symbols();
 };

--- a/parser_library/test/common_testing.h
+++ b/parser_library/test/common_testing.h
@@ -15,7 +15,10 @@
 #ifndef HLASMPLUGIN_HLASMPARSERLIBRARY_COMMON_TESTING_H
 #define HLASMPLUGIN_HLASMPARSERLIBRARY_COMMON_TESTING_H
 
+#include <algorithm>
+#include <iterator>
 #include <utility>
+#include <vector>
 
 #include "antlr4-runtime.h"
 #include "gmock/gmock.h"
@@ -122,6 +125,14 @@ std::optional<std::vector<T>> get_var_vector(hlasm_context& ctx, std::string nam
     }
 
     return result;
+}
+
+inline bool matches_message_codes(const std::vector<diagnostic_s>& d, std::initializer_list<std::string> m)
+{
+    std::vector<std::string> codes;
+    std::transform(d.begin(), d.end(), std::back_inserter(codes), [](const auto& d) { return d.code; });
+
+    return std::is_permutation(codes.begin(), codes.end(), m.begin(), m.end());
 }
 
 #endif

--- a/parser_library/test/context/macro_test.cpp
+++ b/parser_library/test/context/macro_test.cpp
@@ -811,3 +811,19 @@ TEST(macro, invalid_invoked)
 
     EXPECT_TRUE(std::is_permutation(codes.begin(), codes.end(), expected.begin(), expected.end()));
 }
+
+TEST(macro, invalid_prototype)
+{
+    std::string input = R"(
+     MACRO
+&    &LABEL &a=15
+
+     MEND
+)";
+    analyzer a(input);
+    a.analyze();
+    a.collect_diags();
+
+    ASSERT_FALSE(a.diags().empty());
+    EXPECT_EQ(a.diags()[0].code, "E071");
+}

--- a/parser_library/test/context/macro_test.cpp
+++ b/parser_library/test/context/macro_test.cpp
@@ -827,3 +827,20 @@ TEST(macro, invalid_prototype)
     ASSERT_FALSE(a.diags().empty());
     EXPECT_EQ(a.diags()[0].code, "E071");
 }
+
+TEST(macro, invalid_continuation)
+{
+    std::string input = R"(
+     MACRO
+     MAC
+     SAM31                                                             X
+A
+     MEND
+)";
+    analyzer a(input);
+    a.analyze();
+    a.collect_diags();
+
+    ASSERT_FALSE(a.diags().empty());
+    EXPECT_EQ(a.diags()[0].code, "E001");
+}

--- a/parser_library/test/processing/ca_instr_test.cpp
+++ b/parser_library/test/processing/ca_instr_test.cpp
@@ -314,6 +314,23 @@ TEST(AGO, extended_fail)
     EXPECT_TRUE(ctx.get_var_sym(it3));
 }
 
+TEST(AGO, skip_invalid)
+{
+    std::string input(R"(
+      MACRO
+      MAC
+      AGO .SKIP
+      2 a
+.SKIP ANOP
+      MEND
+)");
+    analyzer a(input);
+    a.analyze();
+    a.collect_diags();
+
+    EXPECT_TRUE(a.diags().empty());
+}
+
 TEST(AIF, extended)
 {
     std::string input(R"(

--- a/parser_library/test/processing/ca_instr_test.cpp
+++ b/parser_library/test/processing/ca_instr_test.cpp
@@ -314,23 +314,6 @@ TEST(AGO, extended_fail)
     EXPECT_TRUE(ctx.get_var_sym(it3));
 }
 
-TEST(AGO, skip_invalid)
-{
-    std::string input(R"(
-      MACRO
-      MAC
-      AGO .SKIP
-      2 a
-.SKIP ANOP
-      MEND
-)");
-    analyzer a(input);
-    a.analyze();
-    a.collect_diags();
-
-    EXPECT_TRUE(a.diags().empty());
-}
-
 TEST(AIF, extended)
 {
     std::string input(R"(

--- a/parser_library/test/processing/copy_test.cpp
+++ b/parser_library/test/processing/copy_test.cpp
@@ -605,3 +605,24 @@ TEST(copy, copy_empty_file)
 
     ASSERT_EQ(a.diags().size(), 0U);
 }
+
+TEST(copy, skip_invalid)
+{
+    std::string copybook_content = R"(
+        AGO .SKIP
+        2 a
+a       a                                                              X
+aaaaaaaaa
+.SKIP   ANOP
+)";
+    std::string input = R"(
+        COPY COPYBOOK
+)";
+    mock_parse_lib_provider lib_provider { { "COPYBOOK", copybook_content } };
+    analyzer a(input, analyzer_options { &lib_provider });
+
+    a.analyze();
+    a.collect_diags();
+
+    EXPECT_TRUE(a.diags().empty());
+}

--- a/parser_library/test/processing/occurence_collector_test.cpp
+++ b/parser_library/test/processing/occurence_collector_test.cpp
@@ -39,8 +39,10 @@ struct operand_occurence_analyzer_mock : public processing::statement_analyzer
         processing::statement_provider_kind,
         processing::processing_kind) override
     {
+        const auto* res_stmt = statement.access_resolved();
+        ASSERT_TRUE(res_stmt);
         processing::occurence_collector collector(occ_kind, *a.context().hlasm_ctx, st);
-        const auto& operands = statement.access_resolved()->operands_ref().value;
+        const auto& operands = res_stmt->operands_ref().value;
         std::for_each(operands.begin(), operands.end(), [&](const auto& op) { op->apply(collector); });
     }
 

--- a/parser_library/test/workspace/workspace_test.cpp
+++ b/parser_library/test/workspace/workspace_test.cpp
@@ -323,11 +323,11 @@ TEST_F(workspace_test, did_close_file)
     // 3 files are open
     //	- open codes source1 and source2 with syntax errors using macro ERROR
     //	- macro file lib/ERROR with syntax error
-    // on first reparse, there should be 3 diagnotics from sources and lib/ERROR file
+    // on first reparse, there should be 2x2=4 diagnotics from sources and lib/ERROR file
     ws.did_open_file("source1");
     ws.did_open_file("source2");
-    ASSERT_EQ(collect_and_get_diags_size(ws, file_manager), (size_t)3);
-    EXPECT_TRUE(match_strings({ faulty_macro_path, "source2", "source1" }));
+    ASSERT_EQ(collect_and_get_diags_size(ws, file_manager), (size_t)4);
+    EXPECT_TRUE(match_strings({ faulty_macro_path, faulty_macro_path, "source2", "source1" }));
 
     // when we close source1, only its diagnostics should disapear
     // macro's and source2's diagnostics should stay as it is still open

--- a/parser_library/test/workspace/workspace_test.cpp
+++ b/parser_library/test/workspace/workspace_test.cpp
@@ -323,21 +323,21 @@ TEST_F(workspace_test, did_close_file)
     // 3 files are open
     //	- open codes source1 and source2 with syntax errors using macro ERROR
     //	- macro file lib/ERROR with syntax error
-    // on first reparse, there should be 2x2=4 diagnotics from sources and lib/ERROR file
+    // on first reparse, there should be 3 diagnotics from sources and lib/ERROR file
     ws.did_open_file("source1");
     ws.did_open_file("source2");
-    ASSERT_EQ(collect_and_get_diags_size(ws, file_manager), (size_t)4);
-    EXPECT_TRUE(match_strings({ faulty_macro_path, faulty_macro_path, "source2", "source1" }));
+    EXPECT_EQ(collect_and_get_diags_size(ws, file_manager), (size_t)3);
+    EXPECT_TRUE(match_strings({ faulty_macro_path, "source2", "source1" }));
 
     // when we close source1, only its diagnostics should disapear
     // macro's and source2's diagnostics should stay as it is still open
     ws.did_close_file("source1");
-    ASSERT_EQ(collect_and_get_diags_size(ws, file_manager), (size_t)2);
+    EXPECT_EQ(collect_and_get_diags_size(ws, file_manager), (size_t)2);
     EXPECT_TRUE(match_strings({ faulty_macro_path, "source2" }));
 
     // even though we close the ERROR macro, its diagnostics will still be there as it is a dependency of source2
     ws.did_close_file(faulty_macro_path);
-    ASSERT_EQ(collect_and_get_diags_size(ws, file_manager), (size_t)2);
+    EXPECT_EQ(collect_and_get_diags_size(ws, file_manager), (size_t)2);
     EXPECT_TRUE(match_strings({ faulty_macro_path, "source2" }));
 
     // if we remove the line using ERROR macro in the source2. its diagnostics will be removed as it is no longer a
@@ -347,7 +347,7 @@ TEST_F(workspace_test, did_close_file)
     changes.push_back(document_change({ { 0, 0 }, { 0, 6 } }, new_text.c_str(), new_text.size()));
     file_manager.did_change_file("source2", 1, changes.data(), changes.size());
     ws.did_change_file("source2", changes.data(), changes.size());
-    ASSERT_EQ(collect_and_get_diags_size(ws, file_manager), (size_t)1);
+    EXPECT_EQ(collect_and_get_diags_size(ws, file_manager), (size_t)1);
     EXPECT_TRUE(match_strings({ "source2" }));
 
     // finally if we close the last source2 file, its diagnostics will disappear as well


### PR DESCRIPTION
fix: Syntax errors reported in bilingual macros (closes eclipse/che-che4z-lsp-for-hlasm#144)
fix: Language server crashes on missing MEND.