### PR TITLE
fix: Remove (no longer supported) experimental flags when running WASM server variant on V8 version 9 and newer

### DIFF
--- a/clients/vscode-hlasmplugin/package-lock.json
+++ b/clients/vscode-hlasmplugin/package-lock.json
@@ -771,9 +771,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "13.13.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.1.tgz",
-      "integrity": "sha512-uysqysLJ+As9jqI5yqjwP3QJrhOcUwBjHUlUxPxjbplwKoILvXVsmYWEhfmAQlrPfbRZmhJB007o4L9sKqtHqQ==",
+      "version": "16.4.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.13.tgz",
+      "integrity": "sha512-bLL69sKtd25w7p1nvg9pigE4gtKVpGTPojBFLMkGHXuUgap2sLqQt2qUnqmVCDfzGUL0DRNZP+1prIZJbMeAXg==",
       "dev": true
     },
     "@types/normalize-package-data": {

--- a/clients/vscode-hlasmplugin/package.json
+++ b/clients/vscode-hlasmplugin/package.json
@@ -43,6 +43,7 @@
     "@semantic-release/exec": "^5.0.0",
     "@types/glob": "^5.0.35",
     "@types/mocha": "^7.0.2",
+    "@types/node": "^16.4.13",
     "@types/vscode": "^1.32.3",
     "conventional-changelog-conventionalcommits": "^4.5.0",
     "decache": "^4.5.1",

--- a/clients/vscode-hlasmplugin/src/serverFactory.ts
+++ b/clients/vscode-hlasmplugin/src/serverFactory.ts
@@ -60,18 +60,30 @@ export class ServerFactory {
         else if (method === 'wasm') {
             const server: vscodelc.Executable = {
                 command: process.execPath,
-                args: [
-                    '--experimental-wasm-threads',
-                    '--experimental-wasm-bulk-memory',
-                    path.join(__dirname, '..', 'bin', 'wasm', 'language_server'),
-                    ...getConfig<string[]>('arguments')
-                ]
+                args: this.getWasmArgs()
             };
             return server;
         }
         else {
             throw Error("Invalid method");
         }
+    }
+
+    private getWasmArgs(): Array<string> {
+        const v8Version = process && process.versions && process.versions.v8 || "1.0";
+        const v8Major = +v8Version.split(".")[0];
+        if (v8Major >= 9)
+            return [
+                path.join(__dirname, '..', 'bin', 'wasm', 'language_server'),
+                ...getConfig<string[]>('arguments')
+            ];
+        else
+            return [
+                '--experimental-wasm-threads',
+                '--experimental-wasm-bulk-memory',
+                path.join(__dirname, '..', 'bin', 'wasm', 'language_server'),
+                ...getConfig<string[]>('arguments')
+            ];
     }
 
     private async getPort(): Promise<number> {


### PR DESCRIPTION
fix: Remove (no longer supported) experimental flags when running WASM server variant on V8 version 9 and newer.