### PR TITLE
fix: Remove ALIAS operand parsing limitation

### DIFF
--- a/clients/vscode-hlasmplugin/CHANGELOG.md
+++ b/clients/vscode-hlasmplugin/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Diagnostics lost during JSON serialization
 - Files with extension should not be set to hlasm in libs folder
 - Lookahead mode does not work correctly when triggered from AINSERTed code
+- Remove ALIAS operand parsing limitation
 
 ## [0.14.0](https://github.com/eclipse/che-che4z-lsp-for-hlasm/compare/0.13.0...0.14.0) (2021-08-18)
 

--- a/parser_library/src/checking/asm_instr_check.cpp
+++ b/parser_library/src/checking/asm_instr_check.cpp
@@ -1247,7 +1247,7 @@ bool alias::check(const std::vector<const asm_operand*>& to_check,
         }
         else if (first->operand_identifier[0] == 'X')
         {
-            if (first->operand_identifier.size() % 2 == 1)
+            if ((first->operand_identifier.size() - 3) % 2 == 1)
             {
                 add_diagnostic(diagnostic_op::error_A154_ALIAS_X_format_no_of_chars(first->operand_range));
                 return false;
@@ -1281,10 +1281,6 @@ bool alias::check(const std::vector<const asm_operand*>& to_check,
                 }
             }
             return true;
-        }
-        else
-        {
-            return false;
         }
     }
     add_diagnostic(diagnostic_op::error_A151_ALIAS_op_format(first->operand_range));

--- a/parser_library/src/checking/asm_instr_check.cpp
+++ b/parser_library/src/checking/asm_instr_check.cpp
@@ -1236,7 +1236,7 @@ bool alias::check(const std::vector<const asm_operand*>& to_check,
         {
             // TO DO - no support for four characters in EBCDIC (¢, ¬, ±, ¦) - we throw an error although it should
             // not be
-            std::regex regex(R"([\.<¢\(\+\|&!\$\*\);¬\-\/¦,%_>\?`,:#@\=\"~±\[\]\{\}\^\\a-zA-Z0-9]*)");
+            static const std::regex regex(R"([\.<¢\(\+\|&!\$\*\);¬\-\/¦,%_>\?`,:#@\=\"~±\[\]\{\}\^\\a-zA-Z0-9]*)");
             std::string substr = first->operand_identifier.substr(2, first->operand_identifier.size() - 3);
             if (!std::regex_match(substr, regex))
             {

--- a/parser_library/src/diagnostic.cpp
+++ b/parser_library/src/diagnostic.cpp
@@ -682,6 +682,11 @@ diagnostic_op diagnostic_op::error_A162_PROCESS_uknown_option(const std::string&
         diagnostic_severity::error, "A162", "Error at *PROCESS instruction: unknown assembler option " + option, range);
 }
 
+diagnostic_op diagnostic_op::error_A163_ALIAS_mandatory_label(const range& range)
+{
+    return diagnostic_op(diagnostic_severity::error, "A163", "Label not provided on ALIAS instruction", range);
+}
+
 diagnostic_op diagnostic_op::error_A200_SCOPE_param(const std::string& instr_name, const range& range)
 {
     return diagnostic_op(diagnostic_severity::error,

--- a/parser_library/src/diagnostic.h
+++ b/parser_library/src/diagnostic.h
@@ -279,6 +279,8 @@ struct diagnostic_op
 
     static diagnostic_op error_A162_PROCESS_uknown_option(const std::string& option, const range& range);
 
+    static diagnostic_op error_A163_ALIAS_mandatory_label(const range& range);
+
     // operand parameters
 
     static diagnostic_op error_A200_SCOPE_param(const std::string& instr_name, const range& range);

--- a/parser_library/src/parsing/parser_impl.cpp
+++ b/parser_library/src/parsing/parser_impl.cpp
@@ -235,6 +235,19 @@ bool parser_impl::UNKNOWN()
     return format.form == processing::processing_form::UNKNOWN;
 }
 
+bool parser_impl::ALIAS()
+{
+    static const auto alias_instruction =
+        opcode_t::opcode_variant(&context::instruction::assembler_instructions.at("ALIAS"));
+
+    auto& [format, opcode] = *proc_status;
+    if (format.form != processing::processing_form::ASM)
+        return false;
+
+    auto i = hlasm_ctx->instruction_map().find(opcode.value);
+    return i != hlasm_ctx->instruction_map().end() && i->second == alias_instruction;
+}
+
 antlr4::misc::IntervalSet parser_impl::getExpectedTokens()
 {
     if (proc_status->first.kind == processing::processing_kind::LOOKAHEAD)

--- a/parser_library/src/parsing/parser_impl.cpp
+++ b/parser_library/src/parsing/parser_impl.cpp
@@ -237,15 +237,8 @@ bool parser_impl::UNKNOWN()
 
 bool parser_impl::ALIAS()
 {
-    static const auto alias_instruction =
-        opcode_t::opcode_variant(&context::instruction::assembler_instructions.at("ALIAS"));
-
     auto& [format, opcode] = *proc_status;
-    if (format.form != processing::processing_form::ASM)
-        return false;
-
-    auto i = hlasm_ctx->instruction_map().find(opcode.value);
-    return i != hlasm_ctx->instruction_map().end() && i->second == alias_instruction;
+    return opcode.type == instruction_type::ASM && *opcode.value == "ALIAS";
 }
 
 antlr4::misc::IntervalSet parser_impl::getExpectedTokens()

--- a/parser_library/src/parsing/parser_impl.h
+++ b/parser_library/src/parsing/parser_impl.h
@@ -93,6 +93,7 @@ protected:
     bool CA();
     bool MAC();
     bool UNKNOWN();
+    bool ALIAS();
 
 private:
     antlr4::misc::IntervalSet getExpectedTokens() override;

--- a/parser_library/src/processing/instruction_sets/asm_processor.cpp
+++ b/parser_library/src/processing/instruction_sets/asm_processor.cpp
@@ -642,6 +642,7 @@ asm_processor::process_table_t asm_processor::create_table(context::hlasm_contex
     table.emplace(h_ctx.ids().add("CCW1"), [this](rebuilt_statement stmt) { process_CCW(std::move(stmt)); });
     table.emplace(h_ctx.ids().add("CNOP"), [this](rebuilt_statement stmt) { process_CNOP(std::move(stmt)); });
     table.emplace(h_ctx.ids().add("START"), [this](rebuilt_statement stmt) { process_START(std::move(stmt)); });
+    table.emplace(h_ctx.ids().add("ALIAS"), [this](rebuilt_statement stmt) { process_ALIAS(std::move(stmt)); });
 
     return table;
 }
@@ -815,6 +816,20 @@ void asm_processor::process_START(rebuilt_statement stmt)
     }
 
     hlasm_ctx.ord_ctx.set_available_location_counter_value(start_section_alignment, offset);
+}
+
+void asm_processor::process_ALIAS(rebuilt_statement stmt)
+{
+    if (!check(stmt, hlasm_ctx, checker_, *this))
+        return;
+    auto symbol_name = find_label_symbol(stmt);
+    if (symbol_name->empty())
+    {
+        add_diagnostic(diagnostic_op::error_A163_ALIAS_mandatory_label(stmt.stmt_range_ref()));
+        return;
+    }
+
+    // TODO: check that the symbol_name is an external symbol
 }
 
 } // namespace hlasm_plugin::parser_library::processing

--- a/parser_library/src/processing/instruction_sets/asm_processor.h
+++ b/parser_library/src/processing/instruction_sets/asm_processor.h
@@ -64,6 +64,7 @@ private:
     void process_CCW(rebuilt_statement stmt);
     void process_CNOP(rebuilt_statement stmt);
     void process_START(rebuilt_statement stmt);
+    void process_ALIAS(rebuilt_statement stmt);
 
     template<checking::data_instr_type instr_type>
     void process_data_instruction(rebuilt_statement stmt);

--- a/parser_library/test/checking/asm_instr_check_test.cpp
+++ b/parser_library/test/checking/asm_instr_check_test.cpp
@@ -876,14 +876,10 @@ TEST_F(instruction_test, ainsert)
 
 TEST_F(instruction_test, alias)
 {
-    // TO DO - not working due to self-defining terms issues
-
-    /*
     EXPECT_FALSE(checker.check("ALIAS", test_alias_false, range(), collector));
     EXPECT_TRUE(checker.check("ALIAS", test_alias_true_one, range(), collector));
     EXPECT_TRUE(checker.check("ALIAS", test_alias_true_two, range(), collector));
     EXPECT_FALSE(checker.check("ALIAS", test_acontrol_true, range(), collector));
-    */
 }
 
 TEST_F(instruction_test, amode)

--- a/parser_library/test/processing/asm_instr_test.cpp
+++ b/parser_library/test/processing/asm_instr_test.cpp
@@ -197,3 +197,18 @@ J ALIAS C'STRING'
 
     EXPECT_TRUE(a.diags().empty());
 }
+
+TEST(asm_instr_processing, ALIAS_with_opsyn)
+{
+    std::string input = R"(
+X OPSYN ALIAS
+L X     C'SOMESTRING'
+  EXTRN L
+)";
+
+    analyzer a(input);
+    a.analyze();
+    a.collect_diags();
+
+    EXPECT_TRUE(a.diags().empty());
+}

--- a/parser_library/test/processing/asm_instr_test.cpp
+++ b/parser_library/test/processing/asm_instr_test.cpp
@@ -151,7 +151,7 @@ TEST(asm_instr_processing, ALIAS_mandatory_label)
 
 TEST(asm_instr_processing, ALIAS_external_missing)
 {
-    /* TODO: lable must be an external symbol
+    /* TODO: label must be an external symbol
     std::string input = R"(
 A ALIAS C'SOMESTRING'
 )";


### PR DESCRIPTION
fixes eclipse/che-che4z-lsp-for-hlasm#157