### PR TITLE
ci: Replace theia docker images that do not exist anymore

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -339,7 +339,8 @@ jobs:
     needs: alpine-VSIX
     strategy:
       matrix:
-        theia: ["theiaide/theia", "theiaide/theia:next"]
+        theia: ["quay.io/zowe-explorer/theia:1.18.0"] 
+# theiaide images not supported anymore, replaced with a quay mirror until there is something official again. See also https://github.com/theia-ide/theia-apps/issues/496
     container:
       image: ${{ matrix.theia }}
       options: --user root


### PR DESCRIPTION
`theiaide/theia` image is not supported anymore and all the images disappeared from docker hub recently. See https://github.com/theia-ide/theia-apps/issues/496. Replacing the image with a mirror at quay, hopefully if will work until there is an acceptable replacement on https://github.com/eclipse-theia/theia-blueprint as promised.