### PR TITLE
fix: Single char strings highlighting

### DIFF
--- a/clients/vscode-hlasmplugin/CHANGELOG.md
+++ b/clients/vscode-hlasmplugin/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Behavior of currently supported subscripted system variables corrected
 - Cross-section relative immediate references should be only warned upon
 - Incorrect module layout computed when ORG instruction is used in sections with multiple location counters
+- Highlighting of single character strings (which could represent data attributes - e.g. `I'`, `L'`, `S'` and others) is fixed
 
 ## [1.0.0](https://github.com/eclipse/che-che4z-lsp-for-hlasm/compare/0.15.1...1.0.0) (2022-01-31)
 

--- a/parser_library/src/parsing/grammar/ca_expr_rules.g4
+++ b/parser_library/src/parsing/grammar/ca_expr_rules.g4
@@ -320,7 +320,7 @@ substring returns [expressions::ca_string::substring_t value]
 	|;
 
 ca_string_b returns [ca_expr_ptr ca_expr]
-	: ca_dupl_factor (apostrophe|attr) string_ch_v_c (apostrophe|attr) substring
+	: ca_dupl_factor (apostrophe|attr) string_ch_v_c l_apo substring
 	{
 		auto r = provider.get_range($ca_dupl_factor.ctx->getStart(), $substring.ctx->getStop());
 		$ca_expr = std::make_unique<expressions::ca_string>(std::move($string_ch_v_c.chain), std::move($ca_dupl_factor.value), std::move($substring.value), r);

--- a/parser_library/test/semantics/highlighting_test.cpp
+++ b/parser_library/test/semantics/highlighting_test.cpp
@@ -286,3 +286,49 @@ aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 
     EXPECT_EQ(tokens, expected);
 }
+
+TEST(highlighting, single_chars)
+{
+    std::string source_file = "file_name";
+    const std::string contents = R"(
+&C SETC 'A'
+&C SETC 'B'
+&C SETC 'C'
+&C SETC 'D'
+&C SETC 'E'
+&C SETC 'F'
+&C SETC 'G'
+&C SETC 'H'
+&C SETC 'I'
+&C SETC 'J'
+&C SETC 'K'
+&C SETC 'L'
+&C SETC 'M'
+&C SETC 'N'
+&C SETC 'O'
+&C SETC 'P'
+&C SETC 'Q'
+&C SETC 'R'
+&C SETC 'S'
+&C SETC 'T'
+&C SETC 'U'
+&C SETC 'V'
+&C SETC 'W'
+&C SETC 'X'
+&C SETC 'Y'
+&C SETC 'Z'
+)";
+    analyzer a(contents, analyzer_options { source_file, collect_highlighting_info::yes });
+    a.analyze();
+    const auto& tokens = a.source_processor().semantic_tokens();
+    semantics::lines_info expected;
+
+    for (size_t i = 1; i <= 'Z' - 'A' + 1; ++i)
+    {
+        expected.emplace_back(token_info({ { i, 0 }, { i, 2 } }, hl_scopes::var_symbol));
+        expected.emplace_back(token_info({ { i, 3 }, { i, 7 } }, hl_scopes::instruction));
+        expected.emplace_back(token_info({ { i, 8 }, { i, 11 } }, hl_scopes::string));
+    }
+
+    EXPECT_EQ(tokens, expected);
+}


### PR DESCRIPTION
This PR fixes highlighting for some single char strings (which could represent data attributes - e.g. `I'`, `L'`, `S'` and others).

![image](https://user-images.githubusercontent.com/99467904/159301622-710d9fc9-d55d-47fe-b63d-5ce9cb140495.png)