### PR TITLE
Update README.md

### DIFF
--- a/clients/vscode-hlasmplugin/README.md
+++ b/clients/vscode-hlasmplugin/README.md
@@ -21,6 +21,12 @@ HLASM Language Support is also part of [Code4z](https://marketplace.visualstudio
 
 HLASM Language Support is supported on Visual Studio Code and Github Codespaces.
 
+## Integration with Zowe Explorer
+
+We recommend that you use HLASM Language Support with Zowe Explorer. Zowe Explorer enables you to open your High Level Assembler programs stored on mainframe data sets directly in VS Code.
+
+For more information about the Zowe Explorer extension, see [Zowe Explorer](https://marketplace.visualstudio.com/items?itemName=Zowe.vscode-extension-for-zowe) on the VS Code Marketplace.
+
 ## Getting Started
 
 ### Enabling the Extension


### PR DESCRIPTION
We need to add a new section to the readme for Zowe v2 compliance recommending the use of Zowe Explorer with this extension. I can only think of one benefit, which is opening files from the mainframe, if there are any others let me know.

Signed-off-by: Zeibura Kathau <zeibura.kathau@broadcom.com>